### PR TITLE
Serialize function passes undefined and null values as strings

### DIFF
--- a/src/moltin.coffee
+++ b/src/moltin.coffee
@@ -76,6 +76,8 @@ class Moltin
 
     for k,v of obj
       k = if prefix != null then prefix+'['+k+']' else k
+      if not v?
+        continue
       str.push if typeof v == 'object' then @Serialize v, k else encodeURIComponent(k)+'='+encodeURIComponent(v)
 
     return str.join '&'


### PR DESCRIPTION
There is no need to save undefined and null values as 'undefined' and 'null' strings.
