### PR TITLE
chore: Use scoped package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Moltin JavaScript SDK
 
+[![npm version](https://img.shields.io/npm/v/@moltin/sdk.svg)](https://www.npmjs.com/package/@moltin/sdk)
+
 > A simple to use API interface to help get you off the ground quickly and efficiently with your Moltin JavaScript apps.
 
 📚 [Wiki](https://github.com/moltin/js-sdk/wiki) &mdash; 📚 [API docs](https://moltin.api-docs.io/v2) &mdash; 📚 [moltin.com](https://moltin.com)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Moltin.Authenticate().then((response) => {
 Check out the [wiki](https://github.com/moltin/js-sdk/wiki) to learn more about authenticating and the available endpoints.
 
 
+## Contributing
+
+We love community contributions. Here's a quick guide if you want to submit a pull request:
+
+1. Fork the repository
+2. Add a test for your change (it should fail)
+3. Make the tests pass
+4. Commit your changes (see note below)
+5. Submit your PR with a brief description explaining your changes
+
+> **Note:** Commits should adhere to the [Angular commit conventions](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines).
+
+
 ## Development
 
 The SDK is built with [ES6 modules](https://strongloop.com/strongblog/an-introduction-to-javascript-es6-modules/) that are bundled using [Rollup](http://rollupjs.org).

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Moltin JavaScript SDK
 
-> The Moltin Javascript SDK is a simple to use interface for the Moltin eCommerce API to help you get off the ground quickly and efficiently within client and server applications.
+> A simple to use API interface to help get you off the ground quickly and efficiently with your Moltin JavaScript apps.
 
-[Wiki](https://github.com/moltin/js-sdk/wiki) &mdash; [API docs](https://moltin.api-docs.io/v2) &mdash; [moltin.com](https://moltin.com)
+📚 [Wiki](https://github.com/moltin/js-sdk/wiki) &mdash; 📚 [API docs](https://moltin.api-docs.io/v2) &mdash; 📚 [moltin.com](https://moltin.com)
 
 ## Installation
 
 ```bash
-npm install --save moltin
+npm install --save @moltin/sdk
 ```
 
 #### JavaScript
 
 ```js
-import { gateway as MoltinGateway } from 'moltin';
+import { gateway as MoltinGateway } from '@moltin/sdk';
 ```
 
 #### Node.js
 
 ```js
-const moltin = require('moltin');
+const moltin = require('@moltin/sdk');
 ```
 
 ## Usage
@@ -53,7 +53,7 @@ const Moltin = moltin.gateway({
 });
 ```
 
-You can now authenticate with the Moltin service.
+You can now authenticate with the Moltin service 🎉
 
 ```js
 Moltin.Authenticate().then((response) => {
@@ -66,7 +66,7 @@ Check out the [wiki](https://github.com/moltin/js-sdk/wiki) to learn more about 
 
 ## Development
 
-The SDK is built with [ES6 modules](https://strongloop.com/strongblog/an-introduction-to-javascript-es6-modules/) that are bundled into Node and browser compatible files using [Rollup](http://rollupjs.org).
+The SDK is built with [ES6 modules](https://strongloop.com/strongblog/an-introduction-to-javascript-es6-modules/) that are bundled using [Rollup](http://rollupjs.org).
 
 If you want to roll your own bundle, or make changes to any of the modules in `src`, then you'll need to install the package dependencies and build the `dist` files.
 
@@ -75,4 +75,4 @@ npm install
 npm run build
 ```
 
-You can learn more about Rollup, the API and configuration  [here](https://github.com/rollup/rollup/wiki).
+You can learn more about the Rollup API and configuration  [here](https://github.com/rollup/rollup/wiki).

--- a/README.md
+++ b/README.md
@@ -8,19 +8,17 @@
 
 ## Installation
 
+Install the package from [npm](https://www.npmjs.com/package/@moltin/sdk) and import in your project.
+
 ```bash
 npm install --save @moltin/sdk
 ```
 
-#### JavaScript
-
 ```js
+// ES6 modules
 import { gateway as MoltinGateway } from '@moltin/sdk';
-```
 
-#### Node.js
-
-```js
+// CommonJS modules
 const moltin = require('@moltin/sdk');
 ```
 
@@ -30,29 +28,25 @@ To get started, instantiate a new Moltin client with your store credentials.
 
 > **Note:** This requires a [Moltin](http://moltin.com) account.
 
-#### JavaScript
-
 ```js
+// JavaScript
 const Moltin = MoltinGateway({
   client_id: 'XXX'
+});
+
+// Node.js
+const Moltin = moltin.gateway({
+  client_id: 'XXX',
+  client_secret: 'XXX',
 });
 ```
 
 > **Note:** If you're using [webpack](https://webpack.github.io), you'll need to add the following to your projects configuration file.
 
-```
+```js
 node: {
   fs: 'empty'
 }
-```
-
-#### Node.js
-
-```js
-const Moltin = moltin.gateway({
-  client_id: 'XXX',
-  client_secret: 'XXX',
-});
 ```
 
 You can now authenticate with the Moltin service 🎉

--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
-  "name": "moltin",
+  "name": "@moltin/sdk",
   "description": "SDK for the Moltin eCommerce API",
   "version": "2.1.0",
   "homepage": "https://github.com/moltin/js-sdk",
-  "author": {
-    "name": "Moltin Team",
-    "url": "https://moltin.com/"
-  },
+  "author": "Moltin (https://moltin.com/)",
   "scripts": {
     "roll:cjs": "rollup -c rollup/cjs.config.js",
     "build": "npm run roll:cjs",
@@ -53,5 +50,12 @@
     "verifyConditions": {
       "path": "./node_modules/@krux/condition-jenkins"
     }
+  },
+  "directories": {
+    "test": "test"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moltin/sdk",
   "description": "SDK for the Moltin eCommerce API",
-  "version": "2.1.0",
+  "version": "0.0.0-semantic-release",
   "homepage": "https://github.com/moltin/js-sdk",
   "author": "Moltin (https://moltin.com/)",
   "scripts": {
@@ -19,12 +19,6 @@
   "bugs": {
     "url": "https://github.com/moltin/js-sdk/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/moltin/js-sdk/blob/master/LICENSE"
-    }
-  ],
   "devDependencies": {
     "@krux/condition-jenkins": "^1.0.1",
     "chai": "^3.5.0",


### PR DESCRIPTION
Package now published under `@moltin` scope. Updating docs to reflect that.

```bash
npm install @moltin/sdk
```