### PR TITLE
fix: Set default request body as undefined 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ const Moltin = MoltinGateway({
 });
 ```
 
+Alternatively you can include the `UMD` bundle via [UNPKG](https://unpkg.com) like so:
+
+```js
+<script src="https://unpkg.com/@moltin/sdk">
+
+<script>
+  const Moltin = moltin.gateway({
+    client_id: 'XXX'
+  });
+</script>
+```
+
 > **Note:** If you're using [webpack](https://webpack.github.io), you'll need to add the following to your projects configuration file.
 
 ```js

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -52,7 +52,7 @@ class RequestFactory {
     return promise;
   }
 
-  send(uri, method, body = null) {
+  send(uri, method, body = undefined) {
     const config = this.config;
     const storage = this.storage;
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -109,7 +109,7 @@ export function buildURL(endpoint, params) {
 }
 
 export function buildRequestBody(body) {
-  let parsedBody = null;
+  let parsedBody;
 
   if (body) {
     parsedBody = `{


### PR DESCRIPTION
`GET` requests should never have a body value in payloads. Make sure its `undefined` unless specified.