### PR TITLE
feat: Host config value

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,4 +2,5 @@ extends: airbnb-base
 plugins:
   - import
 rules:
-  indent: ["error", 2, { "MemberExpression": 0}]
+  indent: ["error", 2, { "MemberExpression": 0 }]
+  camelcase: [0, { properties: "never" }]

--- a/README.md
+++ b/README.md
@@ -14,14 +14,6 @@ Install the package from [npm](https://www.npmjs.com/package/@moltin/sdk) and im
 npm install --save @moltin/sdk
 ```
 
-```js
-// ES6 modules
-import { gateway as MoltinGateway } from '@moltin/sdk';
-
-// CommonJS modules
-const MoltinGateway = require('@moltin/sdk').gateway;
-```
-
 ## Usage
 
 To get started, instantiate a new Moltin client with your store credentials.
@@ -30,11 +22,15 @@ To get started, instantiate a new Moltin client with your store credentials.
 
 ```js
 // JavaScript
+import { gateway as MoltinGateway } from '@moltin/sdk';
+
 const Moltin = MoltinGateway({
   client_id: 'XXX'
 });
 
 // Node.js
+const MoltinGateway = require('@moltin/sdk').gateway;
+
 const Moltin = MoltinGateway({
   client_id: 'XXX',
   client_secret: 'XXX',
@@ -70,6 +66,17 @@ Moltin.Authenticate().then((response) => {
 ```
 
 Check out the [wiki](https://github.com/moltin/js-sdk/wiki) to learn more about authenticating and the available endpoints.
+
+### Custom Host
+
+If you're an enterprise customer with your own infrastructure, you'll need to specify your API URL when instantiating:
+
+```js
+const Moltin = MoltinGateway({
+  client_id: 'XXX',
+  host: 'api.yourdomain.com'
+});
+```
 
 
 ## Contributing

--- a/src/config.js
+++ b/src/config.js
@@ -6,18 +6,13 @@ class Config {
     this.client_id = options.client_id;
     this.client_secret = options.client_secret;
     this.host = 'api.moltin.com';
-    this.port = '443';
     this.protocol = 'https';
     this.version = 'v2';
-    this.debug = false;
     this.currency = options.currency;
-    this.language = false;
-    this.timeout = 60000;
     this.auth = {
       expires: 3600,
       uri: 'oauth/access_token',
     };
-    this.methods = ['GET', 'POST', 'PUT', 'DELETE'];
     this.sdk = {
       version,
       language: 'JS',

--- a/src/config.js
+++ b/src/config.js
@@ -2,13 +2,15 @@ import { version } from '../package.json';
 
 class Config {
   constructor(options) {
-    this.application = options.application;
-    this.client_id = options.client_id;
-    this.client_secret = options.client_secret;
-    this.host = 'api.moltin.com';
+    const { application, client_id, client_secret, currency, host } = options;
+
+    this.application = application;
+    this.client_id = client_id;
+    this.client_secret = client_secret;
+    this.host = host || 'api.moltin.com';
     this.protocol = 'https';
     this.version = 'v2';
-    this.currency = options.currency;
+    this.currency = currency;
     this.auth = {
       expires: 3600,
       uri: 'oauth/access_token',

--- a/src/endpoints/currencies.js
+++ b/src/endpoints/currencies.js
@@ -22,8 +22,7 @@ class CurrenciesEndpoint extends BaseExtend {
   }
 
   Set(currency) {
-    const storage = this.storage;
-    const config = this.config;
+    const { config, storage } = this;
 
     storage.set('mcurrency', currency);
     config.currency = currency;

--- a/src/extends/base.js
+++ b/src/extends/base.js
@@ -9,12 +9,14 @@ class BaseExtend {
   }
 
   All() {
+    const { includes, sort, limit, offset, filter } = this;
+
     this.call = this.request.send(buildURL(this.endpoint, {
-      includes: this.includes,
-      sort: this.sort,
-      limit: this.limit,
-      offset: this.offset,
-      filter: this.filter,
+      includes,
+      sort,
+      limit,
+      offset,
+      filter,
     }), 'GET');
 
     return this.call;

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -9,8 +9,7 @@ class RequestFactory {
   }
 
   authenticate() {
-    const config = this.config;
-    const storage = this.storage;
+    const { config, storage } = this;
 
     if (!config.client_id) {
       throw new Error('You must have a client_id set');
@@ -57,8 +56,7 @@ class RequestFactory {
   }
 
   send(uri, method, body = undefined) {
-    const config = this.config;
-    const storage = this.storage;
+    const { config, storage } = this;
 
     const promise = new Promise((resolve, reject) => {
       const req = () => {

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -16,6 +16,10 @@ class RequestFactory {
       throw new Error('You must have a client_id set');
     }
 
+    if (!config.host) {
+      throw new Error('You have not specificed an API host');
+    }
+
     const body = {
       grant_type: config.client_secret ? 'client_credentials' : 'implicit',
       client_id: config.client_id,

--- a/test/unit/authentication.js
+++ b/test/unit/authentication.js
@@ -9,14 +9,11 @@ const MoltinGateway = require('../../dist/moltin.cjs.js').gateway;
 const apiUrl = 'https://api.moltin.com';
 
 describe('Moltin authentication', () => {
-  // Instantiate a Moltin client before each test
-  beforeEach(() => {
+  it('should return an access token', () => {
     Moltin = MoltinGateway({
       client_id: 'XXX',
     });
-  });
 
-  it('should return an access token', () => {
     // Intercept the API request
     nock(apiUrl, {
       reqHeaders: {
@@ -52,14 +49,14 @@ describe('Moltin authentication', () => {
     assert.throws(() => Moltin.Authenticate(), Error, /You must have a client_id set/);
   });
 
-  it('should throw an error when no host is set', () => {
+  it('should fallback to default API host if host is undefined during instantiation', () => {
     // Clear the `host`
     Moltin = MoltinGateway({
       client_id: 'XXX',
-      host: '',
+      host: null,
     });
 
-    assert.throws(() => Moltin.Authenticate(), Error, /You have not specificed an API host/);
+    assert.equal(Moltin.config.host, 'api.moltin.com');
   });
 
   it('should use a custom API host', () => {

--- a/test/unit/authentication.js
+++ b/test/unit/authentication.js
@@ -45,8 +45,30 @@ describe('Moltin authentication', () => {
 
   it('should throw an error when no client id is set', () => {
     // Clear the `client_id`
-    Moltin.config.client_id = '';
+    Moltin = MoltinGateway({
+      client_id: '',
+    });
 
-    assert.throws(() => Moltin.Authenticate(), Error, 'You must have a client_id set');
+    assert.throws(() => Moltin.Authenticate(), Error, /You must have a client_id set/);
+  });
+
+  it('should throw an error when no host is set', () => {
+    // Clear the `host`
+    Moltin = MoltinGateway({
+      client_id: 'XXX',
+      host: '',
+    });
+
+    assert.throws(() => Moltin.Authenticate(), Error, /You have not specificed an API host/);
+  });
+
+  it('should use a custom API host', () => {
+    // Set a custom `host` when instantiating
+    Moltin = MoltinGateway({
+      client_id: 'XXX',
+      host: 'api.test.test',
+    });
+
+    assert.equal(Moltin.config.host, 'api.test.test');
   });
 });


### PR DESCRIPTION
Allow the `host` configuration key to have a custom value assigned during the client instantiation. This is required for enterprise customers using the library.

* Fixes moltin/workflow#2335