### PR TITLE
fix: Handle 204 empty API body on DELETE

### DIFF
--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -16,7 +16,7 @@ class RequestFactory {
     }
 
     if (!config.host) {
-      throw new Error('You have not specificed an API host');
+      throw new Error('You have not specified an API host');
     }
 
     const body = {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -39,6 +39,16 @@ export function cartIdentifier() {
 }
 
 export function parseJSON(response) {
+  if (response.status === 204) {
+    return new Promise((resolve) => {
+      resolve({
+        status: response.status,
+        ok: response.ok,
+        json: '{}',
+      });
+    });
+  }
+
   return new Promise(resolve => response.json()
   .then(json => resolve({
     status: response.status,

--- a/test/unit/brands.js
+++ b/test/unit/brands.js
@@ -111,11 +111,11 @@ describe('Moltin brands', () => {
       },
     })
     .delete('/brands/brand-1')
-    .reply(200, brands[0]);
+    .reply(204);
 
     return Moltin.Brands.Delete(brands[0].id)
     .then((response) => {
-      assert.propertyVal(response, 'id', 'brand-1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -180,11 +180,11 @@ describe('Moltin brands', () => {
         id: 'brand-1',
       }],
     })
-    .reply(200, brands[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'brand', brands[0].id)
     .then((response) => {
-      assert.propertyVal(response, 'id', 'brand-1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -205,11 +205,11 @@ describe('Moltin brands', () => {
         id: 'brand-2',
       }],
     })
-    .reply(200, brands[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'brand', [brands[0].id, brands[1].id])
     .then((response) => {
-      assert.propertyVal(response, 'id', 'brand-1');
+      assert.equal(response, '{}');
     });
   });
 

--- a/test/unit/categories.js
+++ b/test/unit/categories.js
@@ -111,14 +111,11 @@ describe('Moltin categories', () => {
       },
     })
     .delete('/categories/1')
-    .reply(200, {
-      type: 'category',
-      id: '1',
-    });
+    .reply(204);
 
     return Moltin.Categories.Delete('1')
     .then((response) => {
-      assert.propertyVal(response, 'id', '1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -183,11 +180,11 @@ describe('Moltin categories', () => {
         id: 'category-1',
       }],
     })
-    .reply(200, categories[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'category', categories[0].id)
     .then((response) => {
-      assert.propertyVal(response, 'id', 'category-1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -208,11 +205,11 @@ describe('Moltin categories', () => {
         id: 'category-2',
       }],
     })
-    .reply(200, categories[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'category', [categories[0].id, categories[1].id])
     .then((response) => {
-      assert.propertyVal(response, 'id', 'category-1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -230,11 +227,11 @@ describe('Moltin categories', () => {
         id: 'category-1',
       }],
     })
-    .reply(200, categories[0]);
+    .reply(204);
 
     return Moltin.Products.UpdateRelationships(products[0].id, 'category', categories[0].id)
     .then((response) => {
-      assert.propertyVal(response, 'id', 'category-1');
+      assert.equal(response, '{}');
     });
   });
 

--- a/test/unit/collections.js
+++ b/test/unit/collections.js
@@ -107,14 +107,11 @@ describe('Moltin collections', () => {
       },
     })
     .delete('/collections/1')
-    .reply(200, {
-      type: 'collection',
-      id: '1',
-    });
+    .reply(204);
 
     return Moltin.Collections.Delete('1')
     .then((response) => {
-      assert.propertyVal(response, 'id', '1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -179,11 +176,11 @@ describe('Moltin collections', () => {
         id: 'collection-1',
       }],
     })
-    .reply(200, collections[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'collection', collections[0].id)
     .then((response) => {
-      assert.propertyVal(response, 'id', 'collection-1');
+      assert.equal(response, '{}');
     });
   });
 
@@ -204,11 +201,11 @@ describe('Moltin collections', () => {
         id: 'collection-2',
       }],
     })
-    .reply(200, collections[0]);
+    .reply(204);
 
     return Moltin.Products.DeleteRelationships(products[0].id, 'collection', [collections[0].id, collections[1].id])
     .then((response) => {
-      assert.propertyVal(response, 'id', 'collection-1');
+      assert.equal(response, '{}');
     });
   });
 

--- a/test/unit/currencies.js
+++ b/test/unit/currencies.js
@@ -110,14 +110,11 @@ describe('Moltin currencies', () => {
       },
     })
     .delete('/currencies/1')
-    .reply(200, {
-      type: 'currency',
-      id: '1',
-    });
+    .reply(204);
 
     return Moltin.Currencies.Delete('1')
     .then((response) => {
-      assert.propertyVal(response, 'id', '1');
+      assert.equal(response, '{}');
     });
   });
 

--- a/test/unit/products.js
+++ b/test/unit/products.js
@@ -239,14 +239,11 @@ describe('Moltin products', () => {
       },
     })
     .delete('/products/1')
-    .reply(200, {
-      type: 'product',
-      id: '1',
-    });
+    .reply(204);
 
     return Moltin.Products.Delete(1)
     .then((response) => {
-      assert.propertyVal(response, 'id', '1');
+      assert.equal(response, '{}');
     });
   });
 });


### PR DESCRIPTION
A `DELETE` request to the API now returns a `204` status with an empty body (as per the JSON API spec). The existing `parseJSON` function was failing as there was no JSON to parse, and the `fetch` library was throwing an exception.

The helper function now checks the status of the response, and resolves accordingly.