### PR TITLE
fix: Empty array payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "commit": "git-cz",
     "rollup": "rollup -c",
-    "test": "mocha --compilers js:babel-core/register test/unit/*"
+    "test": "mocha --compilers js:babel-core/register test/unit/* test/utils/*"
   },
   "main": "dist/moltin.cjs.js",
   "module": "src/moltin.js",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ export function buildRelationshipData(type, ids) {
   let data = [];
 
   if (ids === null || ids.length === 0) {
-    return '[]';
+    return [];
   }
 
   if (typeof ids === 'string') {

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { buildRelationshipData } from '../../src/utils/helpers';
+
+describe('Build relationship payloads', () => {
+  it('should return an array of relationship key value pairings', () => {
+    const relationships = buildRelationshipData('category', ['123', '456']);
+
+    expect(relationships).to.deep.include.members([
+      { type: 'category', id: '123' },
+      { type: 'category', id: '456' },
+    ]);
+  });
+
+  it('should return an empty array', () => {
+    const relationships = buildRelationshipData('category', null);
+
+    expect(relationships).to.be.an('array').that.is.empty;
+  });
+});


### PR DESCRIPTION
If no IDs are provided to the `buildRelationshipData()` helper function, return an empty array.