### PR TITLE
docs: Fix API reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > A simple to use API interface to help get you off the ground quickly and efficiently with your Moltin JavaScript apps.
 
-📚 [API reference](https://moltin.api-docs.io/v2) &mdash; 📚 [moltin.com](https://moltin.com)
+📚 [API reference](https://docs.moltin.com/?javascript) &mdash; 📚 [moltin.com](https://moltin.com)
 
 ## Installation
 


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Docs
Documentation only changes

## Description
This fixes the link that was previously pointing to the old v2 docs.