### PR TITLE
fix: Include type in customer create payload

### DIFF
--- a/src/endpoints/customers.js
+++ b/src/endpoints/customers.js
@@ -7,7 +7,11 @@ class CustomersEndpoint extends BaseExtend {
     this.endpoint = 'customers';
   }
 
-  Create(body) {
+  Create(customer) {
+    const body = Object.assign(customer, {
+      type: 'customer',
+    });
+
     return this.request.send(`${this.endpoint}`, 'POST', body);
   }
 


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Fix
  Fixes a bug

## Description

This fixes a bug that didn't allow you to create a customer because `type: customer` was missing from the payload being sent to the API.

## Dependencies
None

## Issues
None

## Notes

Error thrown currently is `{"errors":[{"title":"Failed Validation","detail":"The data.type field is required."}]}`

This adds `customer` to the body as there is no other `type` specified in the API reference it seems weird not to do this like we do for `promotion_item`, `custom_item` etc.