### PR TITLE
feat: Added support for CRUD operations with Flows and Flow Entries

### DIFF
--- a/src/endpoints/fields.js
+++ b/src/endpoints/fields.js
@@ -1,0 +1,11 @@
+import CatalogueExtend from '../extends/catalogue';
+
+class FieldsEndpoint extends CatalogueExtend {
+  constructor(endpoint) {
+    super(endpoint);
+
+    this.endpoint = 'fields';
+  }
+}
+
+export default FieldsEndpoint;

--- a/src/endpoints/flows.js
+++ b/src/endpoints/flows.js
@@ -1,0 +1,32 @@
+import CatalogueExtend from '../extends/catalogue';
+
+class FlowsEndpoint extends CatalogueExtend {
+  constructor(endpoint) {
+    super(endpoint);
+
+    this.endpoint = 'flows';
+  }
+
+  GetEntries(slug) {
+    return this.request.send(`${this.endpoint}/${slug}/entries`, 'GET');
+  }
+
+  GetEntry(slug, entry) {
+      return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'GET');
+  }
+
+  CreateEntry(slug, body) {
+    return this.request.send(`${this.endpoint}/${slug}/entries`, 'POST', body);
+  }
+
+  UpdateEntry(slug, entry, body) {
+    return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'PUT', body);
+  }
+
+  DeleteEntry(slug, entry) {
+    return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'DELETE');
+  }
+
+}
+
+export default FlowsEndpoint;

--- a/src/endpoints/flows.js
+++ b/src/endpoints/flows.js
@@ -11,22 +11,21 @@ class FlowsEndpoint extends CatalogueExtend {
     return this.request.send(`${this.endpoint}/${slug}/entries`, 'GET');
   }
 
-  GetEntry(slug, entry) {
-      return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'GET');
+  GetEntry(slug, entryId) {
+      return this.request.send(`${this.endpoint}/${slug}/entries/${entryId}`, 'GET');
   }
 
   CreateEntry(slug, body) {
     return this.request.send(`${this.endpoint}/${slug}/entries`, 'POST', body);
   }
 
-  UpdateEntry(slug, entry, body) {
-    return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'PUT', body);
+  UpdateEntry(slug, entryId, body) {
+    return this.request.send(`${this.endpoint}/${slug}/entries/${entryId}`, 'PUT', body);
   }
 
-  DeleteEntry(slug, entry) {
-    return this.request.send(`${this.endpoint}/${slug}/entries/${entry}`, 'DELETE');
+  DeleteEntry(slug, entryId) {
+    return this.request.send(`${this.endpoint}/${slug}/entries/${entryId}`, 'DELETE');
   }
-
 }
 
 export default FlowsEndpoint;

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -13,8 +13,10 @@ import CollectionsEndpoint from './endpoints/collections';
 import OrdersEndpoint from './endpoints/orders';
 import GatewaysEndpoint from './endpoints/gateways';
 import CustomersEndpoint from './endpoints/customers';
+import FlowsEndpoint from './endpoints/flows';
 
 import { cartIdentifier } from './utils/helpers';
+
 
 export default class Moltin {
   constructor(config) {
@@ -32,6 +34,7 @@ export default class Moltin {
     this.Orders = new OrdersEndpoint(config);
     this.Gateways = new GatewaysEndpoint(config);
     this.Customers = new CustomersEndpoint(config);
+    this.Flows = new FlowsEndpoint(config);
   }
 
   // Expose `Cart` class on Moltin class

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -14,6 +14,7 @@ import OrdersEndpoint from './endpoints/orders';
 import GatewaysEndpoint from './endpoints/gateways';
 import CustomersEndpoint from './endpoints/customers';
 import FlowsEndpoint from './endpoints/flows';
+import FieldsEndpoint from './endpoints/fields';
 
 import { cartIdentifier } from './utils/helpers';
 
@@ -35,6 +36,7 @@ export default class Moltin {
     this.Gateways = new GatewaysEndpoint(config);
     this.Customers = new CustomersEndpoint(config);
     this.Flows = new FlowsEndpoint(config);
+    this.Fields = new FieldsEndpoint(config);
   }
 
   // Expose `Cart` class on Moltin class

--- a/test/factories.js
+++ b/test/factories.js
@@ -216,3 +216,23 @@ export const customersArray = [{
   password: 'securepassword',
   token: 'eXAiOiAiSldUIiB9.eyJzdWIiOiI0YzY',
 }];
+export const flowsArray = [{
+  id: 'flow-1',
+  type: 'flow',
+  name: 'Flow 1',
+  slug: 'flow-1'
+},{
+  id: 'flow-2',
+  type: 'flow',
+  name: 'Flow 2',
+  slug: 'flow-2'
+}];
+export const flowEntriesArray = [{
+  id: 'flow-entry-1',
+  type: 'entry',
+  name: 'Flow Entry 1'
+},{
+  id: 'flow-entry-2',
+  type: 'entry',
+  name: 'Flow Entry 2'
+}];

--- a/test/unit/fields.js
+++ b/test/unit/fields.js
@@ -1,0 +1,106 @@
+import { assert } from 'chai';
+import nock from 'nock';
+import { gateway as MoltinGateway } from '../../src/moltin';
+import { fieldsArray as fields } from '../factories';
+
+const apiUrl = 'https://api.moltin.com/v2';
+
+describe('Moltin flow fields', () => {
+
+  it('should create a field', () => {
+    const Moltin = MoltinGateway({
+        client_id: 'XXX',
+    });
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .post('/fields', {
+      data: {
+        name: 'A new field',
+      },
+    })
+    .reply(201, {
+      name: 'A new field',
+    })
+
+    return Moltin.Fields.Create({
+      name: 'A new field',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'A new field');
+    });
+  });
+
+  it('should update a field', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .put('/fields/1', {
+      data: {
+        name: 'Updated field name',
+      },
+    })
+    .reply(200, {
+      name: 'Updated field name',
+    });
+
+    return Moltin.Fields.Update('1', {
+      name: 'Updated field name',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated field name');
+    });
+  });
+
+  it('should get a field', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/fields/1')
+    .reply(200, {
+      name: 'Updated field name',
+    });
+
+    return Moltin.Fields.Get('1')
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated field name');
+    });
+  });
+
+  it('should delete a field', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .delete('/fields/1')
+    .reply(204);
+
+    return Moltin.Fields.Delete('1')
+    .then((response) => {
+        assert.equal(response, '{}');
+    });
+  });
+});

--- a/test/unit/flows.js
+++ b/test/unit/flows.js
@@ -1,0 +1,165 @@
+import { assert } from 'chai';
+import nock from 'nock';
+import { gateway as MoltinGateway } from '../../src/moltin';
+import { flowsArray as flows, flowEntriesArray as flowEntries } from '../factories';
+
+const apiUrl = 'https://api.moltin.com/v2';
+
+describe('Moltin flows', () => {
+  it('should return an array of flows', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/flows')
+    .reply(200, flows);
+
+    return Moltin.Flows.All()
+    .then((response) => {
+      assert.lengthOf(response, 2);
+    });
+  });
+
+  it('should return a single flow', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/flows/flow-1')
+    .reply(200, flows[0]);
+
+    return Moltin.Flows.Get('flow-1')
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Flow 1');
+    });
+  });
+
+  it('should return an array of flows entries', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/flows/flow-1/entries')
+    .reply(200, flowEntries);
+
+    return Moltin.Flows.GetEntries('flow-1')
+    .then((response) => {
+      assert.lengthOf(response, 2);
+    });
+  });
+
+  it('should create a flow entry', () => {
+    const Moltin = MoltinGateway({
+        client_id: 'XXX',
+    });
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .post('/flows/flow-1/entries', {
+      data: {
+        name: 'A new entry',
+      },
+    })
+    .reply(201, {
+      name: 'A new entry',
+    })
+
+    return Moltin.Flows.CreateEntry('flow-1', {
+      name: 'A new entry',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'A new entry');
+    });
+  });
+
+  it('should update an entry', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .put('/flows/flow-1/entries/1', {
+      data: {
+        name: 'Updated flow name',
+      },
+    })
+    .reply(200, {
+      name: 'Updated flow name',
+    });
+
+    return Moltin.Flows.UpdateEntry('flow-1', '1', {
+      name: 'Updated flow name',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated flow name');
+    });
+  });
+
+  it('should get an entry', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/flows/flow-1/entries/1')
+    .reply(200, {
+      name: 'Updated flow name',
+    });
+
+    return Moltin.Flows.GetEntry('flow-1', '1')
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated flow name');
+    });
+  });
+
+  it('should delete an entry', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .delete('/flows/flow-1/entries/1')
+    .reply(204);
+
+    return Moltin.Flows.DeleteEntry('flow-1', '1')
+    .then((response) => {
+        assert.equal(response, '{}');
+    });
+  });
+});

--- a/test/unit/flows.js
+++ b/test/unit/flows.js
@@ -6,6 +6,104 @@ import { flowsArray as flows, flowEntriesArray as flowEntries } from '../factori
 const apiUrl = 'https://api.moltin.com/v2';
 
 describe('Moltin flows', () => {
+
+  it('should create a flow', () => {
+    const Moltin = MoltinGateway({
+        client_id: 'XXX',
+    });
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .post('/flows', {
+      data: {
+        name: 'A new flow',
+      },
+    })
+    .reply(201, {
+      name: 'A new flow',
+    })
+
+    return Moltin.Flows.Create({
+      name: 'A new flow',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'A new flow');
+    });
+  });
+
+  it('should update a flow', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .put('/flows/flow-1', {
+      data: {
+        name: 'Updated flow name',
+      },
+    })
+    .reply(200, {
+      name: 'Updated flow name',
+    });
+
+    return Moltin.Flows.Update('flow-1', {
+      name: 'Updated flow name',
+    })
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated flow name');
+    });
+  });
+
+  it('should get a flow', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .get('/flows/flow-1')
+    .reply(200, {
+      name: 'Updated flow name',
+    });
+
+    return Moltin.Flows.Get('flow-1')
+    .then((response) => {
+      assert.propertyVal(response, 'name', 'Updated flow name');
+    });
+  });
+
+  it('should delete a flow', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+      },
+    })
+    .delete('/flows/flow-1')
+    .reply(204);
+
+    return Moltin.Flows.Delete('flow-1')
+    .then((response) => {
+        assert.equal(response, '{}');
+    });
+  });
+
   it('should return an array of flows', () => {
     const Moltin = MoltinGateway({
       client_id: 'XXX',


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Feature
  Implements CRUD operations for Flows and Flow Entries

## Description

Added support for CRUD operations on `/flows` and CRUD operations on `/flows/<slug>/entr[y,ies]`. Requires client credential authentication.
