### PR TITLE
fix: Access token cache

### DIFF
--- a/test/unit/authentication.js
+++ b/test/unit/authentication.js
@@ -56,4 +56,82 @@ describe('Moltin authentication', () => {
 
     assert.equal(Moltin.config.host, 'api.test.test');
   });
+
+  it('should cache authentication details', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    })
+    .post('/oauth/access_token', {
+      grant_type: 'implicit',
+      client_id: 'XXX',
+    })
+    .reply(200, {
+      access_token: 'a550d8cbd4a4627013452359ab69694cd446615a',
+      expires: '999999999999999999999',
+    });
+
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+    });
+
+    Moltin.Authenticate().then(() => {
+      const storage = Moltin.request.storage;
+      assert.exists(storage.get('moltinCredentials'));
+    });
+  });
+
+  it('should clear cache if client ID is different', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    })
+    .post('/oauth/access_token', {
+      grant_type: 'implicit',
+      client_id: 'YYY',
+    })
+    .reply(200, {
+      access_token: 'a550d8cbd4a4627013452359ab69694cd446615b',
+      expires: '999999999999999999999',
+    });
+
+    let Moltin = MoltinGateway({
+      client_id: 'YYY',
+    });
+
+    return Moltin.Authenticate().then(() => {
+      let storage = Moltin.request.storage;
+      let credentials = JSON.parse(storage.get('moltinCredentials'));
+      assert.equal(credentials.access_token, 'a550d8cbd4a4627013452359ab69694cd446615b');
+
+      // Intercept the API request
+      nock(apiUrl, {
+        reqheaders: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      })
+      .post('/oauth/access_token', {
+        grant_type: 'implicit',
+        client_id: 'XXX',
+      })
+      .reply(200, {
+        access_token: 'a550d8cbd4a4627013452359ab69694cd446615a',
+        expires: '999999999999999999999',
+      });
+
+      Moltin = MoltinGateway({
+        client_id: 'XXX',
+      });
+
+      return Moltin.Authenticate().then(() => {
+        storage = Moltin.request.storage;
+        credentials = JSON.parse(storage.get('moltinCredentials'));
+        assert.equal(credentials.access_token, 'a550d8cbd4a4627013452359ab69694cd446615a');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Status

* ✅ Ready

## Type
* ### Fix
 
## Description

Fixes an issue where the access token would be cached without reference to a client ID, meaning if the client ID was updated, then the access token would not be refreshed.

This implements a credentials object, which allows us to store the client ID alongside the access token. We check to see if the client ID for the credentials object that we have matches the client ID specified in the config, if not, then we authenticate again.
