### PR TITLE
fix: Fix access_token expiry issue

### DIFF
--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -123,7 +123,7 @@ class RequestFactory {
         !credentials ||
         !credentials.access_token ||
         credentials.client_id !== config.client_id ||
-        Date.now().toString() >= credentials.expires
+        Math.floor(Date.now() / 1000) >= credentials.expires
       ) {
         return this.authenticate()
           .then(req)


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Fix
  Fixes a bug 

## Description

*A brief description of the goals of the pull request.*

* [FIX] Fix `access_token` expiry issue. The length of `Date.now()` int was always greater than the expires value returned from API. This was resulting the `authenicate()` method firing on every request even if there was a valid `access_token` stored

## Dependencies

*Other PRs or builds that this PR depends on.*

* N/A

## Issues

*A list of issues closed by this PR.*

* N/A

## Notes

*Any additional notes.*

* N/A