### PR TITLE
feat: Add ability to use different storage strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ const Moltin = MoltinGateway({
 })
 ```
 
+### Custom Storage
+
+By default the Moltin SDK persists data to `window.localStorage` in the browser and `node-localstorage` in Node. If this doesn't suit your needs you can override the default storage with a `MemoryStorageFactory` which will persist data for the life cycle of the JavaScript VM:
+
+```js
+import { gateway as MoltinGateway, MemoryStorageFactory } from '@moltin/sdk'
+
+const Moltin = MoltinGateway({
+  client_id: 'XXX',
+  storage: new MemoryStorageFactory()
+});
+```
+
+Or alternatively, create your own storage factory by passing in an object which implements the following interface:
+
+```js
+interface StorageFactory {
+  set(key: string, value: string): void;
+  get(key: string): string | null;
+  delete(key: string): void;
+}
+```
+
 ## ❤️ Contributing
 
 We love community contributions. Here's a quick guide if you want to submit a pull request:

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 import { version } from '../package.json'
-import StorageFactory from './factories/storage'
+import LocalStorageFactory from './factories/local-storage'
 
 class Config {
   constructor(options) {
@@ -27,7 +27,7 @@ class Config {
       version,
       language: 'JS'
     }
-    this.storage = storage || new StorageFactory()
+    this.storage = storage || new LocalStorageFactory()
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,16 @@
 import { version } from '../package.json'
+import StorageFactory from './factories/storage'
 
 class Config {
   constructor(options) {
-    const { application, client_id, client_secret, currency, host } = options
+    const {
+      application,
+      client_id,
+      client_secret,
+      currency,
+      host,
+      storage
+    } = options
 
     this.application = application
     this.client_id = client_id
@@ -19,6 +27,7 @@ class Config {
       version,
       language: 'JS'
     }
+    this.storage = storage || new StorageFactory()
   }
 }
 

--- a/src/endpoints/currencies.js
+++ b/src/endpoints/currencies.js
@@ -1,12 +1,11 @@
 import BaseExtend from '../extends/base'
-import StorageFactory from '../factories/storage'
 
 class CurrenciesEndpoint extends BaseExtend {
-  constructor(endpoint) {
-    super(endpoint)
+  constructor(config) {
+    super(config)
 
     this.endpoint = 'currencies'
-    this.storage = new StorageFactory()
+    this.storage = config.storage
   }
 
   Create(body) {

--- a/src/factories/local-storage.js
+++ b/src/factories/local-storage.js
@@ -1,4 +1,4 @@
-class StorageFactory {
+class LocalStorageFactory {
   constructor() {
     if (typeof localStorage === 'undefined' || localStorage === null) {
       const { LocalStorage } = require('node-localstorage')
@@ -22,4 +22,4 @@ class StorageFactory {
   }
 }
 
-export default StorageFactory
+export default LocalStorageFactory

--- a/src/factories/memory-storage.js
+++ b/src/factories/memory-storage.js
@@ -1,0 +1,19 @@
+class MemoryStorageFactory {
+  constructor() {
+    this.state = new Map()
+  }
+
+  set(key, value) {
+    this.state.set(key, value)
+  }
+
+  get(key) {
+    return this.state.get(key) || null
+  }
+
+  delete(key) {
+    this.state.delete(key)
+  }
+}
+
+export default MemoryStorageFactory

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -1,4 +1,3 @@
-import StorageFactory from './storage'
 import { buildRequestBody, parseJSON } from '../utils/helpers'
 
 class Credentials {
@@ -21,7 +20,7 @@ class RequestFactory {
   constructor(config) {
     this.config = config
 
-    this.storage = new StorageFactory()
+    this.storage = config.storage
   }
 
   authenticate() {

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -3,7 +3,6 @@ import 'es6-promise'
 
 import Config from './config'
 import RequestFactory from './factories/request'
-import StorageFactory from './factories/storage'
 import ProductsEndpoint from './endpoints/products'
 import CurrenciesEndpoint from './endpoints/currencies'
 import BrandsEndpoint from './endpoints/brands'
@@ -19,16 +18,18 @@ import FieldsEndpoint from './endpoints/fields'
 import FilesEndpoint from './endpoints/files'
 import AddressesEndpoint from './endpoints/addresses'
 import TransactionsEndpoint from './endpoints/transactions'
+import StorageFactory from './factories/storage'
+import MemoryStorageFactory from './factories/memory-storage'
 
 import { cartIdentifier } from './utils/helpers'
 
 export default class Moltin {
   constructor(config) {
     this.config = config
-    this.cartId = cartIdentifier()
+    this.cartId = cartIdentifier(config.storage)
 
     this.request = new RequestFactory(config)
-    this.storage = new StorageFactory()
+    this.storage = config.storage
 
     this.Products = new ProductsEndpoint(config)
     this.Currencies = new CurrenciesEndpoint(config)
@@ -60,4 +61,4 @@ export default class Moltin {
 // Export a function to instantiate the Moltin class
 const gateway = config => new Moltin(new Config(config))
 
-export { gateway }
+export { gateway, MemoryStorageFactory, StorageFactory }

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -18,7 +18,7 @@ import FieldsEndpoint from './endpoints/fields'
 import FilesEndpoint from './endpoints/files'
 import AddressesEndpoint from './endpoints/addresses'
 import TransactionsEndpoint from './endpoints/transactions'
-import StorageFactory from './factories/storage'
+import LocalStorageFactory from './factories/local-storage'
 import MemoryStorageFactory from './factories/memory-storage'
 
 import { cartIdentifier } from './utils/helpers'
@@ -61,4 +61,4 @@ export default class Moltin {
 // Export a function to instantiate the Moltin class
 const gateway = config => new Moltin(new Config(config))
 
-export { gateway, MemoryStorageFactory, StorageFactory }
+export { gateway, MemoryStorageFactory, LocalStorageFactory }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,7 +1,5 @@
 import { pluralize, underscore } from 'inflected'
 
-import StorageFactory from '../factories/storage'
-
 export function buildRelationshipData(type, ids) {
   let data = []
 
@@ -37,8 +35,7 @@ export function createCartIdentifier() {
   )
 }
 
-export function cartIdentifier() {
-  const storage = new StorageFactory()
+export function cartIdentifier(storage) {
   const cartId = createCartIdentifier()
 
   if (storage.get('mcart') !== null) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,3 +1,4 @@
+require('./unit/config')
 require('./unit/authentication')
 
 // Classes

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -2,13 +2,13 @@ import { expect } from 'chai'
 import {
   gateway as MoltinGateway,
   MemoryStorageFactory,
-  StorageFactory
+  LocalStorageFactory
 } from '../../src/moltin'
 
 describe('storage', () => {
   it('defaults to `StorageFactory`', () => {
     const Moltin = MoltinGateway({})
-    expect(Moltin.storage).to.be.an.instanceof(StorageFactory)
+    expect(Moltin.storage).to.be.an.instanceof(LocalStorageFactory)
     expect(Moltin.config.storage).to.be.equal(Moltin.storage)
     expect(Moltin.request.storage).to.be.equal(Moltin.storage)
     expect(Moltin.Currencies.storage).to.equal(Moltin.storage)

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai'
+import {
+  gateway as MoltinGateway,
+  MemoryStorageFactory,
+  StorageFactory
+} from '../../src/moltin'
+
+describe('storage', () => {
+  it('defaults to `StorageFactory`', () => {
+    const Moltin = MoltinGateway({})
+    expect(Moltin.storage).to.be.an.instanceof(StorageFactory)
+    expect(Moltin.config.storage).to.be.equal(Moltin.storage)
+    expect(Moltin.request.storage).to.be.equal(Moltin.storage)
+    expect(Moltin.Currencies.storage).to.equal(Moltin.storage)
+  })
+
+  it('can be overridden', () => {
+    const memoryStorage = new MemoryStorageFactory()
+    const Moltin = MoltinGateway({
+      storage: memoryStorage
+    })
+    expect(Moltin.storage).to.be.an.instanceof(MemoryStorageFactory)
+    expect(Moltin.config.storage).to.be.equal(Moltin.storage)
+    expect(Moltin.request.storage).to.be.equal(Moltin.storage)
+    expect(Moltin.Currencies.storage).to.be.equal(Moltin.storage)
+  })
+})

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -6,6 +6,7 @@ import {
   createCartIdentifier,
   cartIdentifier
 } from '../../src/utils/helpers'
+import StorageFactory from '../../src/factories/storage'
 
 describe('Build relationship payloads', () => {
   it('should return an array of relationship key value pairings', () => {
@@ -117,6 +118,6 @@ describe('Unique cart identifier', () => {
   })
 
   it('should return a valid cart identifier', () => {
-    expect(cartIdentifier()).to.be.a('string')
+    expect(cartIdentifier(new StorageFactory())).to.be.a('string')
   })
 })

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -6,7 +6,7 @@ import {
   createCartIdentifier,
   cartIdentifier
 } from '../../src/utils/helpers'
-import StorageFactory from '../../src/factories/storage'
+import LocalStorageFactory from '../../src/factories/local-storage'
 
 describe('Build relationship payloads', () => {
   it('should return an array of relationship key value pairings', () => {
@@ -118,6 +118,6 @@ describe('Unique cart identifier', () => {
   })
 
   it('should return a valid cart identifier', () => {
-    expect(cartIdentifier(new StorageFactory())).to.be.a('string')
+    expect(cartIdentifier(new LocalStorageFactory())).to.be.a('string')
   })
 })


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Feature
Custom storage strategies

## Description
Adds ability to pass in custom `StorageFactory` to make the SDK more suitable for environments which don't have access to `window.localStorage` or `fs`.

I've included a `MemoryStorageFactory` out of the box as it's so simple and I imagine all most Node use-cases require.

## Issues
#106 #131