### PR TITLE
fix wrong auth header value format

### DIFF
--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -82,7 +82,7 @@ class RequestFactory {
       const credentials = JSON.parse(storage.get('moltinCredentials'))
       const req = ({ access_token }) => {
         const headers = {
-          Authorization: `Bearer: ${access_token}`,
+          Authorization: `Bearer ${access_token}`,
           'Content-Type': 'application/json',
           'X-MOLTIN-SDK-LANGUAGE': config.sdk.language,
           'X-MOLTIN-SDK-VERSION': config.sdk.version


### PR DESCRIPTION
removed semicolon which is not needed at all and completely blocks all API requests where `client_credentials` are required

## Status

* ✅ Ready

## Type

* ### Fix
  Fixes a bug