### PR TITLE
fix: Update typescript definitions for products endpoint

### DIFF
--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -349,7 +349,7 @@ export namespace moltin {
     constructor(request: RequestFactory, id: string)
     Get<T = any>(): Promise<T>
     Items<T = any>(): Promise<T>
-    AddProduct<T = any>(productId: string, quantity?: number): Promise<T>
+    AddProduct<T = any>(productId: string, quantity?: number, data?: any = {}): Promise<T>
     AddCustomItem<RequestBody = any, ResponseBody = any>(
       body: RequestBody
     ): Promise<ResponseBody>


### PR DESCRIPTION
## Status

* ✅ Ready

## Type

* ### Fix
  Fixes a bug

## Description

This PR aligns `moltin.d.ts` definitions with actual code.
The products endpoint has the following method:
`AddProduct(productId, quantity = 1, data = {})`

The data parameter wasn't included in TypeScript definitions.