### PR TITLE
feat: Flow entries pagination

### DIFF
--- a/src/endpoints/flows.js
+++ b/src/endpoints/flows.js
@@ -1,5 +1,7 @@
 import CRUDExtend from '../extends/crud'
 
+import { buildURL } from '../utils/helpers'
+
 class FlowsEndpoint extends CRUDExtend {
   constructor(endpoint) {
     super(endpoint)
@@ -8,7 +10,15 @@ class FlowsEndpoint extends CRUDExtend {
   }
 
   GetEntries(slug) {
-    return this.request.send(`${this.endpoint}/${slug}/entries`, 'GET')
+    const { limit, offset } = this
+
+    return this.request.send(
+      buildURL(`${this.endpoint}/${slug}/entries`, {
+        limit,
+        offset
+      }),
+      'GET'
+    )
   }
 
   GetEntry(slug, entryId) {

--- a/test/unit/flows.js
+++ b/test/unit/flows.js
@@ -182,7 +182,7 @@ describe('Moltin flows', () => {
     return Moltin.Flows.Limit(4)
       .GetEntries('flow-1')
       .then(response => {
-        assert.lengthOf(response, 4)
+        assert.lengthOf(response, 2)
       })
   })
 
@@ -208,7 +208,7 @@ describe('Moltin flows', () => {
     return Moltin.Flows.Offset(10)
       .GetEntries('flow-1')
       .then(response => {
-        assert.lengthOf(response, 4)
+        assert.lengthOf(response, 2)
       })
   })
 

--- a/test/unit/flows.js
+++ b/test/unit/flows.js
@@ -160,6 +160,58 @@ describe('Moltin flows', () => {
     })
   })
 
+  it('should return a limited number of flow entries', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX'
+    })
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a'
+      }
+    })
+      .get('/flows/flow-1/entries')
+      .query({
+        page: {
+          limit: 4
+        }
+      })
+      .reply(200, flowEntries)
+
+    return Moltin.Flows.Limit(4)
+      .GetEntries('flow-1')
+      .then(response => {
+        assert.lengthOf(response, 4)
+      })
+  })
+
+  it('should return an array flow entries offset by a value', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX'
+    })
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a'
+      }
+    })
+      .get('/flows/flow-1/entries')
+      .query({
+        page: {
+          offset: 10
+        }
+      })
+      .reply(200, flowEntries)
+
+    return Moltin.Flows.Offset(10)
+      .GetEntries('flow-1')
+      .then(response => {
+        assert.lengthOf(response, 4)
+      })
+  })
+
   it('should create a flow entry', () => {
     const Moltin = MoltinGateway({
       client_id: 'XXX'


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature  

## Description

*A brief description of the goals of the pull request.*

* [FEAT] Enabled pagination methods (`Offset()`, `Limit()`) to be chained with `Flows.GetEntries(slug)`.

`Moltin.Flows.Offset(10).Limit(5).GetEntries('blog')`

## Dependencies

*Other PRs or builds that this PR depends on.*

* N/A

## Issues

*A list of issues closed by this PR.*

* N/A

## Notes

*Any additional notes.*

* I'd prefer to refactor the entries resource to be its own class, similar to [addresses](https://github.com/moltin/js-sdk/blob/master/src/endpoints/addresses.js) which is also a sub resource. Consider for future improvement (albeit a *breaking change*).