### PR TITLE
feat: Add custom_fetch to allow alternate WebAPI Fetch implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3618,6 +3618,30 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.2.tgz",
+      "integrity": "sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.3.0",
+        "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "chai": "4.1.2",
     "commitizen": "2.10.1",
+    "cross-fetch": "^3.0.2",
     "cz-conventional-changelog": "2.1.0",
     "eslint": "4.19.1",
     "eslint-config-airbnb-base": "13.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ class Config {
       currency,
       host,
       storage,
-      secure_fetch
+      custom_fetch
     } = options
 
     this.application = application
@@ -23,7 +23,7 @@ class Config {
     this.auth = {
       expires: 3600,
       uri: 'oauth/access_token',
-      fetch: secure_fetch || fetch
+      fetch: custom_fetch || fetch
     }
     this.sdk = {
       version,

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,8 @@ class Config {
       client_secret,
       currency,
       host,
-      storage
+      storage,
+      secure_fetch
     } = options
 
     this.application = application
@@ -21,7 +22,8 @@ class Config {
     this.currency = currency
     this.auth = {
       expires: 3600,
-      uri: 'oauth/access_token'
+      uri: 'oauth/access_token',
+      fetch: secure_fetch || fetch
     }
     this.sdk = {
       version,

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -66,14 +66,18 @@ class RequestFactory {
         .catch(error => reject(error))
     })
 
-    promise.then(response => {
-      const credentials = new Credentials(
-        config.client_id,
-        response.access_token,
-        response.expires
-      )
-      storage.set('moltinCredentials', JSON.stringify(credentials))
-    })
+    promise
+      .then(response => {
+        const credentials = new Credentials(
+          config.client_id,
+          response.access_token,
+          response.expires
+        )
+        storage.set('moltinCredentials', JSON.stringify(credentials))
+      })
+      .catch(() => {
+        storage.delete('moltinCredentials')
+      })
 
     return promise
   }

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -75,9 +75,7 @@ class RequestFactory {
         )
         storage.set('moltinCredentials', JSON.stringify(credentials))
       })
-      .catch(() => {
-        storage.delete('moltinCredentials')
-      })
+      .catch(() => {})
 
     return promise
   }

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -43,17 +43,18 @@ class RequestFactory {
     }
 
     const promise = new Promise((resolve, reject) => {
-      fetch(`${config.protocol}://${config.host}/${config.auth.uri}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'X-MOLTIN-SDK-LANGUAGE': config.sdk.language,
-          'X-MOLTIN-SDK-VERSION': config.sdk.version
-        },
-        body: Object.keys(body)
-          .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(body[k])}`)
-          .join('&')
-      })
+      config.auth.fetch
+        .bind()(`${config.protocol}://${config.host}/${config.auth.uri}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-MOLTIN-SDK-LANGUAGE': config.sdk.language,
+            'X-MOLTIN-SDK-VERSION': config.sdk.version
+          },
+          body: Object.keys(body)
+            .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(body[k])}`)
+            .join('&')
+        })
         .then(parseJSON)
         .then(response => {
           if (response.ok) {
@@ -70,6 +71,7 @@ class RequestFactory {
         config.client_id,
         response.access_token,
         response.expires
+        // Math.min(response.expires, config.auth.expires)
       )
       storage.set('moltinCredentials', JSON.stringify(credentials))
     })

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -71,7 +71,6 @@ class RequestFactory {
         config.client_id,
         response.access_token,
         response.expires
-        // Math.min(response.expires, config.auth.expires)
       )
       storage.set('moltinCredentials', JSON.stringify(credentials))
     })

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -39,6 +39,7 @@ export namespace moltin {
     client_secret?: string
     currency?: string
     host?: string
+    custom_fetch?: Function
   }
 
   export interface Config {
@@ -49,6 +50,7 @@ export namespace moltin {
     protocol: 'https'
     version: 'v2'
     currency?: string
+    custom_fetch?: Function
     auth: {
       expires: 3600
       uri: 'oauth/access_token'

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -36,10 +36,13 @@ describe('Moltin config', () => {
   })
 
   it('custom_fetch will fail must be a Function', () => {
-    // const Moltin = MoltinGateway({
-    //   client_id: 'XXX',
-    //   custom_fetch: 'string'
-    // })
-    // TODO: Negative test
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+      custom_fetch: 'string'
+    })
+
+    return Moltin.Authenticate().catch(error => {
+      expect(error).to.be.an.instanceof(TypeError)
+    })
   })
 })

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -1,12 +1,13 @@
 import { expect } from 'chai'
+import fetch from 'cross-fetch'
 import {
   gateway as MoltinGateway,
   MemoryStorageFactory,
   LocalStorageFactory
 } from '../../src/moltin'
 
-describe('storage', () => {
-  it('defaults to `StorageFactory`', () => {
+describe('Moltin config', () => {
+  it('storage defaults to `StorageFactory`', () => {
     const Moltin = MoltinGateway({})
     expect(Moltin.storage).to.be.an.instanceof(LocalStorageFactory)
     expect(Moltin.config.storage).to.be.equal(Moltin.storage)
@@ -14,7 +15,7 @@ describe('storage', () => {
     expect(Moltin.Currencies.storage).to.equal(Moltin.storage)
   })
 
-  it('can be overridden', () => {
+  it('storage can be overridden', () => {
     const memoryStorage = new MemoryStorageFactory()
     const Moltin = MoltinGateway({
       storage: memoryStorage
@@ -23,5 +24,22 @@ describe('storage', () => {
     expect(Moltin.config.storage).to.be.equal(Moltin.storage)
     expect(Moltin.request.storage).to.be.equal(Moltin.storage)
     expect(Moltin.Currencies.storage).to.be.equal(Moltin.storage)
+  })
+
+  it('custom_fetch can be overridden', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX',
+      custom_fetch: fetch
+    })
+
+    expect(Moltin.config.auth.fetch).to.be.an.instanceof(Function)
+  })
+
+  it('custom_fetch will fail must be a Function', () => {
+    // const Moltin = MoltinGateway({
+    //   client_id: 'XXX',
+    //   custom_fetch: 'string'
+    // })
+    // TODO: Negative test
   })
 })


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
_A brief description of the goals of the pull request._
* Allows `custom_fetch` to be passed into `MoltinGateway` configuration that will be used for authentication calls to API. This allows alternate implementations of the WebAPI Fetch (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec to be used.

```
    const Moltin = MoltinGateway({
      client_id: 'X',
      client_secret: 'X',
      grant_type: 'client_credentials',
      custom_fetch: myCustomWebAPIfetch
    })
```

## Dependencies
_Other PRs or builds that this PR depends on._
* N/A

## Issues

*A list of issues closed by this PR.*

* N/A

## Notes

* Ex. - a scenario where you want to proxy the request for a `client_credentials` token to avoid exposing the `client_secret` in any requests.
