### PR TITLE
feat: Add transaction confirm method

### DIFF
--- a/src/endpoints/transactions.js
+++ b/src/endpoints/transactions.js
@@ -18,6 +18,14 @@ class TransactionsEndpoint extends BaseExtend {
     )
   }
 
+  Confirm({ order, transaction, body }) {
+    return this.request.send(
+      `orders/${order}/transactions/${transaction}/confirm`,
+      'POST',
+      body
+    )
+  }
+
   Refund({ order, transaction }) {
     return this.request.send(
       `orders/${order}/transactions/${transaction}/refund`,

--- a/test/unit/transactions.js
+++ b/test/unit/transactions.js
@@ -73,6 +73,7 @@ describe('Moltin order transactions', () => {
       .post('/orders/order-1/transactions/transaction-1/confirm', {
         data: {
           payment: 'pm_xxx',
+          method: 'purchase',
           gateway: 'stripe_payment_intents'
         }
       })
@@ -83,6 +84,7 @@ describe('Moltin order transactions', () => {
       transaction: 'transaction-1',
       body: {
         payment: 'pm_xxx',
+        method: 'purchase',
         gateway: 'stripe_payment_intents'
       }
     }).then(response => {

--- a/test/unit/transactions.js
+++ b/test/unit/transactions.js
@@ -62,4 +62,31 @@ describe('Moltin order transactions', () => {
       assert.isOk(response)
     })
   })
+
+  it('should confirm an order transaction', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a'
+      }
+    })
+      .post('/orders/order-1/transactions/transaction-1/confirm', {
+        data: {
+          payment: 'pm_xxx',
+          gateway: 'stripe_payment_intents'
+        }
+      })
+      .reply(200, { message: 'transaction approved' })
+
+    return Moltin.Transactions.Confirm({
+      order: 'order-1',
+      transaction: 'transaction-1',
+      body: {
+        payment: 'pm_xxx',
+        gateway: 'stripe_payment_intents'
+      }
+    }).then(response => {
+      assert.propertyVal(response, 'message', 'transaction approved')
+    })
+  })
 })


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature  

## Description

*A brief description of the goals of the pull request.*

* [FEAT] Adds a`Confirm` method to confirm order transaction as a part of the new Stripe PaymentIntents gateway flow

## Dependencies

*Other PRs or builds that this PR depends on.*

* N/A

## Issues

*A list of issues closed by this PR.*

* N/A

## Notes

*Any additional notes.*

* N/A