### PR TITLE
fix: types missing for constructor which causes build errors when usi…

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -70,7 +70,7 @@ export namespace core {
       token?: string
     ): Promise<T>
 
-    constructor(Config)
+    constructor(config: Config): void
   }
 
   export interface ConfigOptions {
@@ -101,7 +101,7 @@ export namespace core {
       language: 'JS'
     }
 
-    constructor(options: ConfigOptions)
+    constructor(options: ConfigOptions): void
   }
 
   export interface StorageFactory {

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -77,6 +77,7 @@ export namespace core {
     application?: string
     client_id: string
     client_secret?: string
+    language?: string
     currency?: string
     host?: string
     custom_fetch?: Function
@@ -89,8 +90,8 @@ export namespace core {
     host: string
     protocol: 'https'
     version: 'v2'
-    currency?: string,
-    language?: string,
+    currency?: string
+    language?: string
     custom_fetch?: Function
     auth: {
       expires: 3600


### PR DESCRIPTION
* Fix

This is a quick fix for the constructors missing some type definitions, which causes a build error when consuming with a strict linter. This pr just adds some type definitions for the constructors.   

* fix

Config options missing language