### PR TITLE
fix: handle main-image data array

### DIFF
--- a/src/endpoints/products.js
+++ b/src/endpoints/products.js
@@ -15,7 +15,7 @@ class ProductsEndpoint extends CRUDExtend {
     return this.request.send(
       `${this.endpoint}/${id}/relationships/${parsedType}`,
       'POST',
-      body
+      type === 'main-image' ? body[0] : body
     )
   }
 
@@ -26,7 +26,7 @@ class ProductsEndpoint extends CRUDExtend {
     return this.request.send(
       `${this.endpoint}/${id}/relationships/${parsedType}`,
       'DELETE',
-      body
+      type === 'main-image' ? body[0] : body
     )
   }
 
@@ -37,7 +37,7 @@ class ProductsEndpoint extends CRUDExtend {
     return this.request.send(
       `${this.endpoint}/${id}/relationships/${parsedType}`,
       'PUT',
-      body
+      type === 'main-image' ? body[0] : body
     )
   }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -8,8 +8,6 @@ export function buildRelationshipData(type, ids) {
   if (typeof ids === 'string') {
     const obj = { type: underscore(type), id: ids }
 
-    if (type === 'main-image') return obj
-
     return [obj]
   }
 

--- a/test/unit/files.ts
+++ b/test/unit/files.ts
@@ -221,6 +221,30 @@ describe('Moltin files', () => {
     })
   })
 
+  it('should create a product-main_image relationship with an array', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a'
+      }
+    })
+      .post('/products/product-1/relationships/main-image', {
+        data: {
+          type: 'main_image',
+          id: 'file-1'
+        }
+      })
+      .reply(200, files[0])
+
+    return Moltin.Products.CreateRelationships(
+      products[0].id,
+      'main-image',
+      [files[0].id]
+    ).then(response => {
+      assert.propertyVal(response, 'id', 'file-1')
+    })
+  })
+
   it('should delete a product-main_image relationship', () => {
     // Intercept the API request
     nock(apiUrl, {


### PR DESCRIPTION
## Type

Fix

## Description

This fixes some unexpected SDK behaviour when following the code example given in the documentation at
https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/products/relationships/main-image-relationship.html

These docs say to run

    Moltin.Products.CreateRelationships(pid, 'main-image', [iid])

but that code fails prior to this commit.

A conditional in `buildRelationshipData` was causing either a single relationship object or an array of such objects to be returned:

| ID \ type | `main-image`  | other        |
| --------- | ------------- | ------------ |
| string    | return object | return array |
| array     | return array  | return array |

The `CreateRelationships`, `DeleteRelationships`, and `UpdateRelationships` endpoints all require a single object rather than
an array of objects, so the code in the documentation, which passes an array rather than a string, was failing with `The data.type field is required` and `The data.id field is required`.

This commit adds a test (which fails before the rest of the commit and passes after), removes the conditional from `buildRelationshipData` so it always returns an array of objects, and instead adds the conditional in the `Create`/`Delete`/`UpdateRelationships` implementations.

Only the first ID is used, no matter how many are given.