### PR TITLE
feat: Implements the ability to assign customer id to cart

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -75,6 +75,21 @@ class CartEndpoint extends BaseExtend {
     return this.request.send(`${this.endpoint}`, 'GET', undefined, token)
   }
 
+  AddCustomerAssociation(customerId, token) {
+    const body = [
+      {
+        type: 'customer',
+        id: customerId
+      }
+    ]
+    return this.request.send(
+      `${this.endpoint}/${this.cartId}/relationships/customers`,
+      'POST',
+      body,
+      token
+    )
+  }
+
   RemoveItem(itemId) {
     return this.request.send(
       `${this.endpoint}/${this.cartId}/items/${itemId}`,

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -144,6 +144,8 @@ export interface CartEndpoint {
 
   GetCartsList(token?: string): Promise<CartItemsResponse>;
 
+  AddCustomerAssociation(customerId: string, token: string ): Promise<CartItemsResponse>;
+
   /**
    * @deprecated Use UpdateItem method
    */

--- a/test/unit/cart.ts
+++ b/test/unit/cart.ts
@@ -831,4 +831,29 @@ describe('Moltin cart', () => {
         assert.propertyVal(response, 'id', '1')
       })
   })
+
+  it('should add a customer id association to the cart using a JWT', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+        'X-MOLTIN-CUSTOMER-TOKEN': 'testtoken'
+      }
+    })
+      .post('/carts/5/relationships/customers', {
+        data: [
+          {
+            type: 'customer',
+            id: 'customer-1'
+          }
+        ]
+      })
+      .reply(200, {})
+
+    return Moltin.Cart('5')
+      .AddCustomerAssociation('customer-1', 'testtoken')
+      .then(response => {
+        assert.isObject(response)
+      })
+  })
 })


### PR DESCRIPTION
## Type

* ### Feature
  Implements the ability to assign customer id to cart


## Notes

`POST /v2/carts/:cart_id/relationships/customers` returns `null`
 But `nock` didn't allow that, so I used `{}` for the test: https://github.com/moltin/js-sdk/pull/346/files#diff-8452f0531ec683589e7912ada26baf3cR800
