### PR TITLE
feat: expose accounts and store API endpoints

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,8 @@ class Config {
       language,
       host,
       storage,
-      custom_fetch
+      custom_fetch,
+      authenticate
     } = options
 
     this.application = application
@@ -32,6 +33,7 @@ class Config {
       language: 'JS'
     }
     this.storage = storage || new LocalStorageFactory()
+    this.authenticate = authenticate
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,7 @@ class Config {
       host,
       storage,
       custom_fetch,
-      authenticate
+      custom_authenticator
     } = options
 
     this.application = application
@@ -33,7 +33,7 @@ class Config {
       language: 'JS'
     }
     this.storage = storage || new LocalStorageFactory()
-    this.authenticate = authenticate
+    this.custom_authenticator = custom_authenticator
   }
 }
 

--- a/src/endpoints/accounts.js
+++ b/src/endpoints/accounts.js
@@ -28,7 +28,7 @@ class AccountsEndpoint extends BaseExtend {
     )
   }
 
-  StoresSwitch(storeId) {
+  SwitchStore(storeId) {
     return this.request.send(
       `account/stores/switch/${storeId}`,
       'GET',

--- a/src/endpoints/accounts.js
+++ b/src/endpoints/accounts.js
@@ -1,0 +1,32 @@
+import BaseExtend from '../extends/base'
+
+class AccountsEndpoint extends BaseExtend {
+  constructor(endpoint) {
+    super(endpoint)
+
+    this.endpoint = 'accounts'
+    this.version = 'v1'
+  }
+
+  Stores() {
+    return this.request.send(
+      `${this.endpoint}/stores`,
+      'GET',
+      undefined,
+      undefined,
+      this
+    )
+  }
+
+  Keys() {
+    return this.request.send(
+      `${this.endpoint}/keys`,
+      'GET',
+      undefined,
+      undefined,
+      this
+    )
+  }
+}
+
+export default AccountsEndpoint

--- a/src/endpoints/accounts.js
+++ b/src/endpoints/accounts.js
@@ -18,6 +18,26 @@ class AccountsEndpoint extends BaseExtend {
     )
   }
 
+  Store(id) {
+    return this.request.send(
+      `${this.endpoint}/stores/${id}`,
+      'GET',
+      undefined,
+      undefined,
+      this
+    )
+  }
+
+  StoresSwitch(storeId) {
+    return this.request.send(
+      `account/stores/switch/${storeId}`,
+      'GET',
+      undefined,
+      undefined,
+      this
+    )
+  }
+
   Keys() {
     return this.request.send(
       `${this.endpoint}/keys`,

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -115,7 +115,7 @@ class RequestFactory {
           headers['X-MOLTIN-CUSTOMER-TOKEN'] = token
         }
 
-        const version = instance.version || config.version
+        const version = (instance && instance.version) || config.version
 
         fetch(`${config.protocol}://${config.host}/${version}/${uri}`, {
           method: method.toUpperCase(),

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -68,8 +68,8 @@ class RequestFactory {
   authenticate() {
     const { config, storage } = this
 
-    const promise = config.authenticate
-      ? config.authenticate()
+    const promise = config.custom_authenticator
+      ? config.custom_authenticator()
       : createAuthRequest(config)
 
     promise

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -68,7 +68,9 @@ class RequestFactory {
   authenticate() {
     const { config, storage } = this
 
-    const promise = config.authenticate() || createAuthRequest(config)
+    const promise = config.authenticate
+      ? config.authenticate()
+      : createAuthRequest(config)
 
     promise
       .then(response => {

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -16,6 +16,49 @@ class Credentials {
   }
 }
 
+const createAuthRequest = config => {
+  if (!config.client_id) {
+    throw new Error('You must have a client_id set')
+  }
+
+  if (!config.host) {
+    throw new Error('You have not specified an API host')
+  }
+
+  const body = {
+    grant_type: config.client_secret ? 'client_credentials' : 'implicit',
+    client_id: config.client_id
+  }
+
+  if (config.client_secret) {
+    body.client_secret = config.client_secret
+  }
+
+  return new Promise((resolve, reject) => {
+    config.auth.fetch
+      .bind()(`${config.protocol}://${config.host}/${config.auth.uri}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-MOLTIN-SDK-LANGUAGE': config.sdk.language,
+          'X-MOLTIN-SDK-VERSION': config.sdk.version
+        },
+        body: Object.keys(body)
+          .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(body[k])}`)
+          .join('&')
+      })
+      .then(parseJSON)
+      .then(response => {
+        if (response.ok) {
+          resolve(response.json)
+        }
+
+        reject(response.json)
+      })
+      .catch(error => reject(error))
+  })
+}
+
 class RequestFactory {
   constructor(config) {
     this.config = config
@@ -25,46 +68,7 @@ class RequestFactory {
   authenticate() {
     const { config, storage } = this
 
-    if (!config.client_id) {
-      throw new Error('You must have a client_id set')
-    }
-
-    if (!config.host) {
-      throw new Error('You have not specified an API host')
-    }
-
-    const body = {
-      grant_type: config.client_secret ? 'client_credentials' : 'implicit',
-      client_id: config.client_id
-    }
-
-    if (config.client_secret) {
-      body.client_secret = config.client_secret
-    }
-
-    const promise = new Promise((resolve, reject) => {
-      config.auth.fetch
-        .bind()(`${config.protocol}://${config.host}/${config.auth.uri}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'X-MOLTIN-SDK-LANGUAGE': config.sdk.language,
-            'X-MOLTIN-SDK-VERSION': config.sdk.version
-          },
-          body: Object.keys(body)
-            .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(body[k])}`)
-            .join('&')
-        })
-        .then(parseJSON)
-        .then(response => {
-          if (response.ok) {
-            resolve(response.json)
-          }
-
-          reject(response.json)
-        })
-        .catch(error => reject(error))
-    })
+    const promise = config.authenticate() || createAuthRequest(config)
 
     promise
       .then(response => {
@@ -109,7 +113,9 @@ class RequestFactory {
           headers['X-MOLTIN-CUSTOMER-TOKEN'] = token
         }
 
-        fetch(`${config.protocol}://${config.host}/${config.version}/${uri}`, {
+        const version = instance.version || config.version
+
+        fetch(`${config.protocol}://${config.host}/${version}/${uri}`, {
           method: method.toUpperCase(),
           headers,
           body: buildRequestBody(body)

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -23,6 +23,7 @@ import * as file from './types/file';
 import * as flow from './types/flow';
 import * as transaction from './types/transaction';
 import * as settings from './types/settings';
+import * as accounts from './types/accounts';
 
 export * from './types/config';
 export * from './types/storage';
@@ -46,6 +47,7 @@ export * from './types/file';
 export * from './types/flow';
 export * from './types/transaction';
 export * from './types/settings';
+export * from './types/accounts';
 
 // UMD
 export as namespace moltin
@@ -72,6 +74,7 @@ export class Moltin {
   Addresses: address.AddressesEndpoint;
   Transactions: transaction.TransactionEndpoint;
   Settings: settings.SettingsEndpoint;
+  Accounts: accounts.AccountsEndpoint;
 
   Cart(id?: string): cart.CartEndpoint; // This optional cart id is super worrying when using the SDK in a node server :/
   constructor(config: config.Config);

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -23,6 +23,7 @@ import TransactionsEndpoint from './endpoints/transactions'
 import SettingsEndpoint from './endpoints/settings'
 import LocalStorageFactory from './factories/local-storage'
 import MemoryStorageFactory from './factories/memory-storage'
+import AccountsEndpoint from './endpoints/accounts'
 
 import { cartIdentifier } from './utils/helpers'
 
@@ -51,6 +52,7 @@ export default class Moltin {
     this.Addresses = new AddressesEndpoint(config)
     this.Transactions = new TransactionsEndpoint(config)
     this.Settings = new SettingsEndpoint(config)
+    this.Accounts = new AccountsEndpoint(config)
   }
 
   // Expose `Cart` class on Moltin class

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -1,0 +1,65 @@
+/**
+ * Accounts
+ * Description:
+ *
+ * DOCS:
+ */
+
+import { Resource } from './core';
+
+/**
+ * Account Endpoints
+ */
+
+export interface StoreUserAvatar {
+  large: string
+  medium: string
+  small: string
+}
+
+export interface StoreUser {
+  id: string
+  name: string
+  email: string
+  role: string
+  avatar: StoreUserAvatar
+}
+export interface KeysItemResponse {
+  client_id: string
+  client_secret: string
+  store_id: string
+  store_uuid: string
+  user_id: string
+}
+
+export interface SwitchStoreResponse {
+  status: number
+  title: string
+}
+
+export interface StoreResponse {
+  features: string[]
+  id: string
+  locked: boolean
+  name: string
+  owner: string
+  store_status: string
+  stripe_customer_id: string | null
+  subscription_status: string | null
+  trial_end: string | null
+  trial_start: string | null
+  users: StoreUser[]
+  uuid: string
+}
+
+export interface CartEndpoint {
+  endpoint: 'accounts'
+
+  Stores(): Promise<Resource<StoreResponse[]>>
+
+  Store(storeId: string): Promise<Resource<StoreResponse>>
+
+  SwitchStore(storeId: string): Promise<Resource<SwitchStoreResponse>>
+
+  Keys(): Promise<Resource<KeysItemResponse[]>>
+}

--- a/src/types/accounts.d.ts
+++ b/src/types/accounts.d.ts
@@ -5,7 +5,7 @@
  * DOCS:
  */
 
-import { Resource } from './core';
+import { QueryableResource, Resource } from './core';
 
 /**
  * Account Endpoints
@@ -15,6 +15,29 @@ export interface StoreUserAvatar {
   large: string
   medium: string
   small: string
+}
+
+export interface Account {
+  application_types: string[]
+  avatar: StoreUserAvatar
+  company: string | null
+  company_size: string | null
+  company_type: string | null
+  created_at: string
+  current_store: string | null
+  email: string
+  id: string
+  job_title: string | null
+  languages: string[]
+  name: string
+  onboarded: boolean
+  opt_in: boolean
+  organisation_id: string
+  project_timeline: string | null
+  signup_intention: string | null
+  tutorial_modal_viewed: boolean
+  updated_at: string
+  user_role: string
 }
 
 export interface StoreUser {
@@ -37,7 +60,7 @@ export interface SwitchStoreResponse {
   title: string
 }
 
-export interface StoreResponse {
+export interface Store {
   features: string[]
   id: string
   locked: boolean
@@ -52,12 +75,17 @@ export interface StoreResponse {
   uuid: string
 }
 
-export interface CartEndpoint {
+export interface AccountsEndpoint extends QueryableResource<
+  Account,
+  never,
+  never,
+  never
+  >{
   endpoint: 'accounts'
 
-  Stores(): Promise<Resource<StoreResponse[]>>
+  Stores(): Promise<Resource<Store[]>>
 
-  Store(storeId: string): Promise<Resource<StoreResponse>>
+  Store(storeId: string): Promise<Resource<Store>>
 
   SwitchStore(storeId: string): Promise<Resource<SwitchStoreResponse>>
 

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -25,8 +25,8 @@ export interface ConfigOptions {
   currency?: string;
   host?: string;
   custom_fetch?: Function;
+  custom_authenticator?: () => Promise<CustomAuthenticatorResponseBody>;
   storage?: StorageFactory;
-  authenticate?: () => Promise<AuthenticateResponseBody>;
 }
 
 export interface Config {
@@ -39,6 +39,7 @@ export interface Config {
   currency?: string;
   language?: string;
   custom_fetch?: Function;
+  custom_authenticator?: () => Promise<CustomAuthenticatorResponseBody>;
   auth: {
     expires: 3600;
     uri: 'oauth/access_token';
@@ -73,3 +74,9 @@ export interface AuthenticateResponseBody {
   access_token: string;
   token_type: 'Bearer';
 }
+
+export interface CustomAuthenticatorResponseBody {
+  expires: number;
+  access_token: string;
+}
+

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -26,6 +26,7 @@ export interface ConfigOptions {
   host?: string;
   custom_fetch?: Function;
   storage?: StorageFactory;
+  authenticate?: () => Promise<AuthenticateResponseBody>;
 }
 
 export interface Config {

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -1,4 +1,4 @@
-import { Address, Brand, BrandBase } from "../src/moltin"
+import {Address, Brand, BrandBase, KeysItemResponse as Key, Store, Account} from '../src/moltin'
 
 export const integrationsArray = [
   {
@@ -465,4 +465,79 @@ export const notFoundError = {
       title: 'Product not found'
     }
   ]
+}
+
+export const storesArray: Store[] = [
+  {
+    features: ["core"],
+    id: "store-1",
+    locked: false,
+    name: "name",
+    owner: "12312312",
+    store_status: "test",
+    stripe_customer_id: null,
+    subscription_status: null,
+    trial_end: null,
+    trial_start: null,
+    users: [],
+    uuid: "123-123-123",
+  },
+  {
+    features: ["core"],
+    id: "store-2",
+    locked: false,
+    name: "name",
+    owner: "12312312",
+    store_status: "test",
+    stripe_customer_id: null,
+    subscription_status: null,
+    trial_end: null,
+    trial_start: null,
+    users: [],
+    uuid: "123-123-123",
+  }
+]
+
+export const keysArray: Key[] = [
+  {
+    client_id: "client_id-1",
+    client_secret: "client_secret-1",
+    store_id: "store_id-1",
+    store_uuid: "store_uuid-1",
+    user_id: "user_id-1"
+  },
+  {
+    client_id: "client_id-2",
+    client_secret: "client_secret-2",
+    store_id: "store_id-2",
+    store_uuid: "store_uuid-2",
+    user_id: "user_id-2"
+  }
+]
+
+export const account: Account = {
+  application_types: [],
+  avatar: {
+    small: 'link',
+    large: 'link',
+    medium: 'link',
+  },
+  company: null,
+  company_size: null,
+  company_type: null,
+  created_at: "2020-04-06 08:16:48",
+  current_store: null,
+  email: "123@elasticpath.com",
+  id: "123",
+  job_title: null,
+  languages: [],
+  name: "John Dou",
+  onboarded: true,
+  opt_in: false,
+  organisation_id: "321",
+  project_timeline: null,
+  signup_intention: null,
+  tutorial_modal_viewed: false,
+  updated_at: "2020-04-06 08:16:48",
+  user_role: "other"
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -21,6 +21,7 @@ require('./unit/products')
 require('./unit/transactions')
 require('./unit/error')
 require('./unit/settings')
+require('./unit/accounts')
 
 // Utilities
 require('./utils/helpers')

--- a/test/unit/accounts.ts
+++ b/test/unit/accounts.ts
@@ -1,0 +1,102 @@
+import { assert } from 'chai'
+import nock from 'nock'
+import {
+  CustomAuthenticatorResponseBody,
+  gateway as MoltinGateway
+} from '../../src/moltin'
+import { storesArray as stores, keysArray as keys, account } from '../factories'
+
+const apiUrl = 'https://api.moltin.com/v1'
+const accessToken = 'testaccesstoken'
+const auth = (): Promise<CustomAuthenticatorResponseBody> =>
+  new Promise(resolve =>
+    resolve({
+      expires: 99999999999,
+      access_token: accessToken
+    })
+  )
+
+describe('Moltin accounts', () => {
+  const Moltin = MoltinGateway({
+    custom_authenticator: auth
+  })
+
+  it('should return an account', () => {
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: `Bearer: ${accessToken}`
+      }
+    })
+      .get('/accounts')
+      .reply(200, { data: account })
+
+    return Moltin.Accounts.All().then(response => {
+      assert.propertyVal(response.data, 'id', '123')
+    })
+  })
+
+  it('should return an array of stores', () => {
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: `Bearer: ${accessToken}`
+      }
+    })
+      .get('/accounts/stores')
+      .reply(200, { data: stores })
+
+    return Moltin.Accounts.Stores().then(response => {
+      assert.lengthOf(response.data, 2)
+    })
+  })
+
+  it('should return an a single store', () => {
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: `Bearer: ${accessToken}`
+      }
+    })
+      .get('/accounts/stores/store-1')
+      .reply(200, { data: stores[0] })
+
+    return Moltin.Accounts.Store('store-1').then(response => {
+      assert.propertyVal(response.data, 'id', 'store-1')
+    })
+  })
+
+  it('should switch store', () => {
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: `Bearer: ${accessToken}`
+      }
+    })
+      .get('/account/stores/switch/store-1')
+      .reply(200, {
+        data: {
+          status: 200,
+          title: 'Store switched successfully to: store-1'
+        }
+      })
+
+    return Moltin.Accounts.SwitchStore('store-1').then(response => {
+      assert.propertyVal(
+        response.data,
+        'title',
+        'Store switched successfully to: store-1'
+      )
+    })
+  })
+
+  it('should return an array of keys', () => {
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: `Bearer: ${accessToken}`
+      }
+    })
+      .get('/accounts/keys')
+      .reply(200, { data: keys })
+
+    return Moltin.Accounts.Keys().then(response => {
+      assert.lengthOf(response.data, 2)
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2015"],                                /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
## Type

* ### Feature
PCM APIs exposed through JS-SDK

## Description
Added ability to use PCM APIs by creating alternative auth flow

Code for testing
```
  const authenticate = () => {
      const body = {
        grant_type: 'password',
        username: '',
        password: '',
        client_id: '',
        client_secret: ''
      }

      return fetch('https://api.moltin.com/oauth/access_token', {
        method: 'POST',
        headers: {
          'Content-Type': 'application/x-www-form-urlencoded'
        },
        body: Object.keys(body)
                .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(body[k])}`)
                .join('&')
      }).then(res => res.json())
    }

    const Moltin = moltin.gateway({
      authenticate
    })

    Moltin.Authenticate().then(res => console.log(res))
    Moltin.Accounts.All().then(({ data }) => console.log(data))
    Moltin.Accounts.Keys().then(({ data }) => console.log('Keys',data))
    Moltin.Accounts.Stores().then(({ data }) => {
      Moltin.Accounts.StoresSwitch(data[0].id).then(() => {
        Moltin.Products.All().then(({ data }) => console.log(data))
      })
    })
```
