### PR TITLE
fix: update cart meta type to reflect SDK response

### DIFF
--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -48,10 +48,10 @@ export interface Cart {
       with_tax?: FormattedPrice
       without_tax?: FormattedPrice
       tax?: FormattedPrice
-      timestamps?: {
-        created_at: string
-        updated_at: string
-      }
+    }
+    timestamps?: {
+      created_at: string
+      updated_at: string
     }
   }
 }

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -45,21 +45,9 @@ export interface Cart {
   links?: {}
   meta?: {
     display_price?: {
-      with_tax?: {
-        amount: number
-        currency: string
-        formatted: string
-      }
-      display_price?: {
-        amount: number
-        currency: string
-        formatted: string
-        tax: {
-          amount: number
-          currency: string
-          formatted: string
-        }
-      }
+      with_tax?: FormattedPrice
+      without_tax?: FormattedPrice
+      tax?: FormattedPrice
       timestamps?: {
         created_at: string
         updated_at: string


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Currently, the TypeScript type for `cart` does not match [the docs](https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/index.html) and the response from the SDK.

**For example:**
* `cart.meta.display_price.tax` and `cart.meta.display_price.without_tax` are never valid according to the existing type def, but are optional according to the docs.
* `cart.meta.display_price.display_price.tax` is a valid (optional) path under the existing type def. I don't think output is ever expected from the SDK.

## Dependencies

_(none)_

## Issues

There is no open issue for this, but I can open one if needed.

## Notes

I've made use of your existing `FormattedPrice` interface in this update. It contains all of the correct values and seems to have been made for this purpose. Previously, the values were typed explicitly. It's possible this was intentional and that changing `FormattedPrice` in the future will have unintended consequences. In which case, we could simply update `display_price` using the code below instead.

```ts
display_price?: {
  with_tax?: {
    amount: number
    currency: string
    formatted: string
  }
  without_tax?: {
    amount: number
    currency: string
    formatted: string
  }
  tax?: {
    amount: number
    currency: string
    formatted: string
  }
  timestamps?: {
    created_at: string
    updated_at: string
  }
}
```
