### PR TITLE
fix: order relationships types

### DIFF
--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -43,8 +43,8 @@ export interface Order extends Identifiable, OrderBase {
     }
   }
   relationships?: {
-    main_image?: Relationship<'product'>[]
-    categories?: Relationship<'customer'>
+    items?: Relationship<'product'>[]
+    customer?: Relationship<'customer'>
   }
 }
 


### PR DESCRIPTION
## Type

* ### Fix
Fix for order relationships types

## Description
Updated order relationships types to same as in documentation https://documentation.elasticpath.com/commerce-cloud/docs/api/orders-and-customers/orders/index.html#docsNav

Thanks to @yasiloghmani for finding that issue.