### PR TITLE
feat: Exposed PCM endpoints

### DIFF
--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -1,0 +1,13 @@
+import CRUDExtend from '../extends/crud'
+
+class PCMEndpoint extends CRUDExtend {
+  constructor(endpoint) {
+    const config = { ...endpoint } // Need to clone config so it is only updated in PCM
+    config.version = 'experimental'
+    super(config)
+
+    this.endpoint = 'products'
+  }
+}
+
+export default PCMEndpoint

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -1,32 +1,31 @@
 // Type definitions for @moltin/js-sdk
 // Project: @moltin/sdk
-
-import * as config from './types/config'
-import * as storage from './types/storage'
-import * as product from './types/product'
-import * as core from './types/core'
-import * as customer from './types/customer'
-import * as order from './types/order'
-import * as cart from './types/cart'
-import * as address from './types/address'
-import * as inventory from './types/inventory'
-import * as field from './types/field'
-import * as collection from './types/collection'
-import * as category from './types/category'
-import * as brand from './types/brand'
-import * as currency from './types/currency'
-import * as integration from './types/integration'
-import * as job from './types/job'
-import * as file from './types/file'
-import * as flow from './types/flow'
-import * as transaction from './types/transaction'
-import * as settings from './types/settings'
-import * as promotions from './types/promotions'
-import * as variations from './types/variations'
-import * as authenticationSettings from './types/authentication-settings'
-import * as oidcProfile from './types/oidc-profile'
-import * as authenticationRealm from './types/authentication-realm'
-import * as paymentGateway from './types/gateway'
+import { AuthenticateResponseBody, Config, ConfigOptions, RequestFactory } from './types/config'
+import { StorageFactory } from './types/storage'
+import { ProductsEndpoint } from './types/product'
+import { PcmProductsEndpoint } from './types/pcm'
+import { CurrencyEndpoint } from './types/currency'
+import { BrandEndpoint } from './types/brand'
+import { CategoryEndpoint } from './types/category'
+import { CollectionEndpoint } from './types/collection'
+import { IntegrationEndpoint } from './types/integration'
+import { OrdersEndpoint } from './types/order'
+import { GatewaysEndpoint } from './types/gateway'
+import { CustomersEndpoint } from './types/customer'
+import { InventoryEndpoint } from './types/inventory'
+import { JobEndpoint } from './types/job'
+import { FileEndpoint } from './types/file'
+import { FlowEndpoint } from './types/flow'
+import { FieldsEndpoint } from './types/field'
+import { AddressesEndpoint } from './types/address'
+import { TransactionEndpoint } from './types/transaction'
+import { SettingsEndpoint } from './types/settings'
+import { PromotionsEndpoint } from './types/promotions'
+import { VariationsEndpoint } from './types/variations'
+import { AuthenticationSettingsEndpoint } from './types/authentication-settings'
+import { OidcProfileEndpoint } from './types/oidc-profile'
+import { AuthenticationRealmEndpoint } from './types/authentication-realm'
+import { CartEndpoint } from './types/cart'
 
 export * from './types/config'
 export * from './types/storage'
@@ -43,6 +42,7 @@ export * from './types/collection'
 export * from './types/category'
 export * from './types/brand'
 export * from './types/currency'
+export * from './types/pcm'
 export * from './types/integration'
 export * from './types/job'
 export * from './types/file'
@@ -60,40 +60,41 @@ export * from './types/gateway'
 export as namespace moltin
 
 export class Moltin {
-  config: config.Config
+  config: Config
   cartId?: string
-  request: config.RequestFactory
-  storage: storage.StorageFactory
-  Products: product.ProductsEndpoint
-  Currencies: currency.CurrencyEndpoint
-  Brands: brand.BrandEndpoint
-  Categories: category.CategoryEndpoint
-  Collections: collection.CollectionEndpoint
-  Integrations: integration.IntegrationEndpoint
-  Orders: order.OrdersEndpoint
-  Gateways: paymentGateway.GatewaysEndpoint
-  Customers: customer.CustomersEndpoint
-  Inventories: inventory.InventoryEndpoint
-  Jobs: job.JobEndpoint
-  Files: file.FileEndpoint
-  Flows: flow.FlowEndpoint
-  Fields: field.FieldsEndpoint
-  Addresses: address.AddressesEndpoint
-  Transactions: transaction.TransactionEndpoint
-  Settings: settings.SettingsEndpoint
-  Promotions: promotions.PromotionsEndpoint
-  Variations: variations.VariationsEndpoint
-  AuthenticationSettings: authenticationSettings.AuthenticationSettingsEndpoint
-  OidcProfile: oidcProfile.OidcProfileEndpoint
-  AuthenticationRealm: authenticationRealm.AuthenticationRealmEndpoint
+  request: RequestFactory
+  storage: StorageFactory
+  Products: ProductsEndpoint
+  PCM: PcmProductsEndpoint
+  Currencies: CurrencyEndpoint
+  Brands: BrandEndpoint
+  Categories: CategoryEndpoint
+  Collections: CollectionEndpoint
+  Integrations: IntegrationEndpoint
+  Orders: OrdersEndpoint
+  Gateways: GatewaysEndpoint
+  Customers: CustomersEndpoint
+  Inventories: InventoryEndpoint
+  Jobs: JobEndpoint
+  Files: FileEndpoint
+  Flows: FlowEndpoint
+  Fields: FieldsEndpoint
+  Addresses: AddressesEndpoint
+  Transactions: TransactionEndpoint
+  Settings: SettingsEndpoint
+  Promotions: PromotionsEndpoint
+  Variations: VariationsEndpoint
+  AuthenticationSettings: AuthenticationSettingsEndpoint
+  OidcProfile: OidcProfileEndpoint
+  AuthenticationRealm: AuthenticationRealmEndpoint
 
-  Cart(id?: string): cart.CartEndpoint // This optional cart id is super worrying when using the SDK in a node server :/
-  constructor(config: config.Config)
+  Cart(id?: string): CartEndpoint // This optional cart id is super worrying when using the SDK in a node server :/
+  constructor(config: Config)
 
-  Authenticate(): Promise<config.AuthenticateResponseBody>
+  Authenticate(): Promise<AuthenticateResponseBody>
 }
 
-export function gateway(config: config.ConfigOptions): Moltin
+export function gateway(config: ConfigOptions): Moltin
 
 export namespace moltin {
   export interface Settings {

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -7,6 +7,7 @@ import ProductsEndpoint from './endpoints/products'
 import CurrenciesEndpoint from './endpoints/currencies'
 import BrandsEndpoint from './endpoints/brands'
 import CartEndpoint from './endpoints/cart'
+import PCMEndpoint from './endpoints/pcm'
 import CategoriesEndpoint from './endpoints/categories'
 import CollectionsEndpoint from './endpoints/collections'
 import IntegrationsEndpoint from './endpoints/integrations'
@@ -43,6 +44,7 @@ export default class Moltin {
     this.storage = config.storage
 
     this.Products = new ProductsEndpoint(config)
+    this.PCM = new PCMEndpoint(config)
     this.Currencies = new CurrenciesEndpoint(config)
     this.Brands = new BrandsEndpoint(config)
     this.Categories = new CategoriesEndpoint(config)

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -41,7 +41,7 @@ export interface Config {
   client_secret?: string
   host: string
   protocol: 'https'
-  version: 'v1' | 'v2' | 'v3'
+  version: 'v1' | 'v2' | 'v3' | 'experimental'
   currency?: string
   language?: string
   custom_fetch?: Function

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Products
+ * Description: Products are the core resource to any Commerce Cloud project. They can be associated by category, collection, brands, and more.
+ */
+import {
+  Identifiable,
+  CrudQueryableResource
+} from './core'
+
+/**
+ * Core PCM Product Base Interface
+ * For custom flows, extend this interface
+ */
+export interface PcmProductBase {
+  type: string
+  attributes: {
+    name: string
+    description?: string
+    slug: string
+    sku: string
+    status?: string
+    commodity_type?: string
+    upc_ean?: number
+    mpn?: string
+  }
+}
+
+export interface PcmProduct extends Identifiable, PcmProductBase {
+  meta: {
+    // TODO
+  }
+}extends/base.js
+
+
+export interface PcmProductFilter {
+  // TODO
+}
+
+type PcmProductSort = // TODO
+  | 'name'
+
+type PcmProductInclude = // TODO
+  | 'price'
+
+/**
+ * PCM Product Endpoints
+ */
+export interface PcmProductsEndpoint
+  extends CrudQueryableResource<PcmProduct,
+    PcmProductBase,
+    Partial<PcmProductBase>,
+    PcmProductFilter,
+    PcmProductSort,
+    PcmProductInclude> {
+  endpoint: 'products'
+}


### PR DESCRIPTION
[DO NOT MERGE INTO MASTER]

This branch exposes the PCM endpoints in the SDK via the `experimental` version on the integration environment. This calls will fail on master - and hence we need to push this as a beta. 

In order to get this to work with the new PCM endpoints on integration environment, is set up your moltin instance as such:

```
const moltin: Moltin = gateway({
  disableCart: true,
  host: 'epcc-integration.global.ssl.fastly.net', // must point to integration environment!!
  'client_id': 'xxx,
  'client_secret': xxx'
});
```

note: Make sure you get your credentials from `https://ep-dashboard-integration.netlify.app` not the main dashboard - as this is pointing to integration. 

You will then need to authenticate the instance ie: 

```
const auth = await moltin.Authenticate();
```

and then you will be able to use full crud with new PCM Services (All, Create, Update, Delete)

eg `const pcmProducts = await moltin.PCM.All();` etc...