### PR TITLE
feat: add support for customer specific promotions

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -57,13 +57,14 @@ class CartEndpoint extends BaseExtend {
     )
   }
 
-  AddPromotion(code) {
+  AddPromotion(code, customerToken = null) {
     const body = buildCartItemData(code, null, 'promotion_item')
 
     return this.request.send(
       `${this.endpoint}/${this.cartId}/items`,
       'POST',
-      body
+      body,
+      customerToken
     )
   }
 

--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -57,14 +57,14 @@ class CartEndpoint extends BaseExtend {
     )
   }
 
-  AddPromotion(code, customerToken = null) {
+  AddPromotion(code, token = null) {
     const body = buildCartItemData(code, null, 'promotion_item')
 
     return this.request.send(
       `${this.endpoint}/${this.cartId}/items`,
       'POST',
       body,
-      customerToken
+      token
     )
   }
 

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -64,8 +64,6 @@ export interface CartItemBase {
   [key: string]: any
 }
 
-
-
 /**
  * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/cart-items/index.html
  */
@@ -135,7 +133,6 @@ export interface CartItemObject {
   code?: string
 }
 
-
 export interface CartEndpoint
   extends QueryableResource<Cart, never, never, never> {
   endpoint: 'carts'
@@ -163,7 +160,7 @@ export interface CartEndpoint
   AddProduct(
     productId: string,
     quantity?: number,
-    data?: any, 
+    data?: any,
     isSku?: boolean
   ): Promise<CartItemsResponse>
 
@@ -181,7 +178,7 @@ export interface CartEndpoint
    * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/add-promotion-to-cart.html
    * @param code the promotion code.
    */
-  AddPromotion(code: string): Promise<CartItemsResponse>
+  AddPromotion(code: string, customerToken?: string): Promise<CartItemsResponse>
 
   /**
    * Get a Cart by reference

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -177,8 +177,9 @@ export interface CartEndpoint
    * Description: You can use the Promotions API to apply discounts to your cart as a special cart item type.
    * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/add-promotion-to-cart.html
    * @param code the promotion code.
+   * @param token a customer token to apply customer specific promotions.
    */
-  AddPromotion(code: string, customerToken?: string): Promise<CartItemsResponse>
+  AddPromotion(code: string, token?: string): Promise<CartItemsResponse>
 
   /**
    * Get a Cart by reference

--- a/test/unit/cart.ts
+++ b/test/unit/cart.ts
@@ -158,7 +158,7 @@ describe('Moltin cart', () => {
             timestamps: {
               created_at: '2020-08-21T01:45:59Z',
               updated_at: '2020-08-21T01:45:59Z',
-              expires_at: '2020-08-28T01:45:59Z',
+              expires_at: '2020-08-28T01:45:59Z'
             }
           }
         }
@@ -184,7 +184,7 @@ describe('Moltin cart', () => {
         timestamps: {
           created_at: '2020-08-21T01:45:59Z',
           updated_at: '2020-08-21T01:45:59Z',
-          expires_at: '2020-08-28T01:45:59Z',
+          expires_at: '2020-08-28T01:45:59Z'
         }
       }
     }
@@ -621,6 +621,30 @@ describe('Moltin cart', () => {
       })
   })
 
+  it('should add a promotion to the cart with a customer token', () => {
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a',
+        'X-MOLTIN-CUSTOMER-TOKEN': 'abcd-1234'
+      }
+    })
+      .post('/carts/3/items', {
+        data: {
+          type: 'promotion_item',
+          code: 'testcode'
+        }
+      })
+      .reply(201, { name: 'Custom Item', quantity: 1 })
+
+    return Moltin.Cart()
+      .AddPromotion('testcode', 'abcd-1234')
+      .then(response => {
+        assert.propertyVal(response, 'name', 'Custom Item')
+        assert.propertyVal(response, 'quantity', 1)
+      })
+  })
+
   it('should add a promotion to the cart with a cart id argument', () => {
     // Intercept the API request
     nock(apiUrl, {
@@ -675,7 +699,7 @@ describe('Moltin cart', () => {
             type: 'promotion_item',
             code: 'testcode'
           }
-        ], 
+        ],
         options: { add_all_or_nothing: false }
       })
       .reply(201, {


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description

Add the ability to pass a customer token on add promotion requests, to support customer specific promotions

## Issues

https://elasticpath.atlassian.net/browse/MT-6856