### PR TITLE
[MT-7458] Include account and account member into the orders

### DIFF
--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -2,7 +2,8 @@ export interface Identifiable {
   id: string
 }
 
-export interface Resource<R> {
+export interface Resource<R, E> {
+  included?: E
   data: R
 }
 

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -3,7 +3,6 @@ export interface Identifiable {
 }
 
 export interface Resource<R, E> {
-  included?: E
   data: R
 }
 

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -2,7 +2,7 @@ export interface Identifiable {
   id: string
 }
 
-export interface Resource<R, E> {
+export interface Resource<R> {
   data: R
 }
 

--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -45,6 +45,8 @@ export interface Order extends Identifiable, OrderBase {
   relationships?: {
     items?: Relationship<'product'>[]
     customer?: Relationship<'customer'>
+    account?: Relationship<'account'>
+    account_member?: Relationship<'account_member'>
   }
 }
 
@@ -190,7 +192,7 @@ export interface ConfirmPaymentResponse {
 }
 
 type OrderSort = 'created_at' | 'payment' | 'shipping' | 'status' | 'with_tax'
-type OrderInclude = 'product' | 'customer' | 'items'
+type OrderInclude = 'product' | 'customer' | 'items' | 'account' | 'account_member'
 
 /**
  * Orders Endpoints

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -264,7 +264,37 @@ export const ordersArray = [
   {
     id: 'order-1',
     type: 'order',
-    status: 'complete'
+    status: 'complete',
+    relationships: {
+      account: {
+        data: {
+          type: 'account',
+          id: '1c45e4ec-26e0-4043-86e4-c15b9cf985a1'
+        }
+      },
+      account_member: {
+        data: {
+          type: 'account_member',
+          id: '7c45e4ec-26e0-4043-86e4-c15b9cf985a1'
+        }
+      }
+    },
+    included:{
+      accounts: [{
+          type: 'account',
+          id: '1c45e4ec-26e0-4043-86e4-c15b9cf985a1',
+          legal_name: 'my legal name',
+          name: 'my name',
+        }
+      ],
+      account_members: [{
+          type: 'account_member',
+          id: '7c45e4ec-26e0-4043-86e4-c15b9cf985a1',
+          email: 'test@ep.com',
+          name: 'test account'
+        }
+      ]
+    }
   },
   {
     id: 'order-2',

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -136,7 +136,6 @@ describe('Moltin orders', () => {
     return Moltin.Orders.With(['account', 'account_member']).Get(orders[0].id).then(response => {
       assert.propertyVal(response, 'id', 'order-1')
       assert.propertyVal(response, 'status', 'complete')
-      const { included } =  response
       assert.lengthOf(response.included.accounts, 1)
       assert.lengthOf(response.included.account_members, 1)
     })

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -133,7 +133,7 @@ describe('Moltin orders', () => {
         .get('/orders/order-1?include=account,account_member')
         .reply(200, orders[0])
 
-    return Moltin.Orders.With(['account', 'account_member']).Get(orders[0].id).then(response => {
+    return Moltin.Orders.With(['account', 'account_member']).Get(orders[0].id).then((response:any) => {
       assert.propertyVal(response, 'id', 'order-1')
       assert.propertyVal(response, 'status', 'complete')
       assert.lengthOf(response.included.accounts, 1)

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -119,6 +119,29 @@ describe('Moltin orders', () => {
     })
   })
 
+  it('should return a single order include account and account_member', () => {
+    const Moltin = MoltinGateway({
+      client_id: 'XXX'
+    })
+
+    // Intercept the API request
+    nock(apiUrl, {
+      reqheaders: {
+        Authorization: 'Bearer: a550d8cbd4a4627013452359ab69694cd446615a'
+      }
+    })
+        .get('/orders/order-1?include=account,account_member')
+        .reply(200, orders[0])
+
+    return Moltin.Orders.With(['account', 'account_member']).Get(orders[0].id).then(response => {
+      assert.propertyVal(response, 'id', 'order-1')
+      assert.propertyVal(response, 'status', 'complete')
+      const { included } =  response
+      assert.lengthOf(response.included.accounts, 1)
+      assert.lengthOf(response.included.account_members, 1)
+    })
+  })
+
   it('should return a single order using a JWT', () => {
     const Moltin = MoltinGateway({
       client_id: 'XXX'


### PR DESCRIPTION
## Type

* ### Feature
  Include account and account member into the orders
## Description
when we call order endpoint with include in query of account or account_member, it should return included items.
`GET /orders/order-1?include=account,account_member`

## Dependencies

- https://gitlab.elasticpath.com/commerce-cloud/gateway.svc/-/merge_requests/631
- https://code.elasticpath.com/internal-pd/docs-ep-commerce-cloud/-/merge_requests/449
