### PR TITLE
 fix: update types in PCMProductBase

### DIFF
--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -16,13 +16,13 @@ export interface PcmProductBase {
   type: string
   attributes: {
     name: string
-    description?: string
-    slug: string
+    description?: string | null
+    slug?: string | null
     sku: string
     status?: string
     commodity_type?: string
-    upc_ean?: string
-    mpn?: string
+    upc_ean?: string | null
+    mpn?: string | null
   }
 }
 


### PR DESCRIPTION
## Description
Update types in pcmProductBase .

When I UPDATE product with "sku" "Partial-UpdateProduct" as | slug | description | mpn | upc_ean | | null | null | null | null |