### PR TITLE
feat: Add discount to OrderItemd Type

### DIFF
--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -146,6 +146,16 @@ export interface OrderItem extends Identifiable, OrderItemBase {
     cart_item: Relationship<'cart_item'>
     taxes: Relationship<'taxes'>[]
   }
+  discounts?: [
+    {
+      amount: {
+        amount: number
+        currency: string
+        includes_tax: string
+      }
+      code: string
+    }
+  ]
 }
 
 export interface ConfirmPaymentBody {


### PR DESCRIPTION
## Type

* ### Feature
 As a Dashboard user, I would like to see the line item discounts if there is any item promotions.


## Description
Update OrderItem Type in order
As a Dashboard user, I would like to see the line item discounts if there is any item promotions.

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

https://elasticpath.atlassian.net/browse/MT-8096
