### PR TITLE
fix: custom fetch for all requests

### DIFF
--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -134,16 +134,17 @@ class RequestFactory {
           Object.assign(headers, additionalHeaders)
         }
 
-        fetch(
-          `${config.protocol}://${config.host}/${
-            version || config.version ? `${version || config.version}/` : ''
-          }${uri}`,
-          {
-            method: method.toUpperCase(),
-            headers,
-            body: wrapBody ? buildRequestBody(body) : JSON.stringify(body)
-          }
-        )
+        config.auth.fetch
+          .bind()(
+            `${config.protocol}://${config.host}/${
+              version || config.version ? `${version || config.version}/` : ''
+            }${uri}`,
+            {
+              method: method.toUpperCase(),
+              headers,
+              body: wrapBody ? buildRequestBody(body) : JSON.stringify(body)
+            }
+          )
           .then(parseJSON)
           .then(response => {
             if (response.ok) {


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

The `custom_fetch` parameter for `Moltin` is used only for authentication request. 
As I understand, the idea was to replace `fetch` in every request made by the SDK.
So, I adjusted `RequestFactory`'s `send` method.
