### PR TITLE
performance: Adds retry jitter to the retry for 429 requests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,8 @@ class Config {
       reauth,
       protocol,
       store_id,
-      retryDelay
+      retryDelay,
+      retryJitter
     } = options
 
     this.application = application
@@ -45,6 +46,7 @@ class Config {
     this.disableCart = disableCart || false
     this.reauth = reauth || true
     this.retryDelay = retryDelay || 1000
+    this.retryJitter = retryJitter || 500
   }
 }
 

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -87,7 +87,8 @@ const fetchRetry = (
               )
                 .then(result => resolve(result))
                 .catch(error => reject(error)),
-            attempt * config.retryDelay
+            attempt * config.retryDelay +
+              Math.floor(Math.random() * config.retryJitter)
           )
         } else {
           reject(response.json)

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -34,6 +34,7 @@ export interface ConfigOptions {
   disableCart?: Boolean
   reauth?: Boolean,
   retryDelay?: number
+  retryJitter?: number
 }
 
 export interface Config {
@@ -57,7 +58,8 @@ export interface Config {
     language: 'JS'
   }
   storage?: StorageFactory
-  retryDelay: number
+  retryDelay?: number
+  retryJitter?: number
 
   constructor(options: ConfigOptions): void
 }

--- a/test/unit/error.ts
+++ b/test/unit/error.ts
@@ -12,7 +12,8 @@ const apiUrl = 'https://api.moltin.com/v2'
 describe('Moltin error handling', () => {
   const Moltin = MoltinGateway({
     client_id: 'XXX',
-    retryDelay: 10 // Reduce retryDelay for retries during testing
+    retryDelay: 10, // Reduce retryDelay/retryJitter for retries during testing
+    retryJitter: 1
   })
 
   it('should handle a 429 correctly', () => {


### PR DESCRIPTION
## Type

* ### Performance
  A code change that improves performance

## Description

*A brief description of the goals of the pull request.*
Adds `retryJitter` parameter to the sdk that defaults to 0.5 a second (or 500 milliseconds). When performing a retry a value between 0 to .5 seconds will be added to the retry value to create a jitter. This helps decorrolate and smooth out traffic over time.
