### PR TITLE
feat: add new option to catalog products include

### DIFF
--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -16,7 +16,7 @@ interface CatalogQueryableResource<Endpoints, DataType, Filter> {
 
 }
 
-type CatalogProductsInclude = 'main_image' | 'files'
+type CatalogProductsInclude = 'main_image' | 'files' | 'component_products'
 
 interface CatalogProductsQueryableResource<
   Endpoints,


### PR DESCRIPTION
'component_products' can be used as an include parameter on the catalog products endpoint, but the sdk hasn't supported it yet.

* ### Feature
  Implements a new feature
