### PR TITLE
[DEVOPS-3298] ci: fix npm release issue due to github action misconfiguration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,10 @@ jobs:
           yarn install
           yarn rollup
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-bundles
-          path: ./**/dist/
+          path: dist
           retention-days: 3
 
   test:
@@ -103,9 +103,10 @@ jobs:
           node-version: '16.10.0'
           cache: 'yarn'
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-bundles
+          path: dist
       - name: Release, publish package
         run: |
           yarn install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}-${{ github.run_id }}-bundles
-          path: dist
+          path: ./**/dist/
           retention-days: 3
 
   test:


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Existing CI configuration uploads artifacts into npmjs with incorrect folder structure. When github action downloads artifacts from build job, it automatically flattens the file structure. This PR adds configuration to maintain the file structure so that npmjs artifact contains `dist` directory.
