### PR TITLE
feat(New endpoint): Added support for DataEntries endpoint

### DIFF
--- a/src/endpoints/data-entry.js
+++ b/src/endpoints/data-entry.js
@@ -1,0 +1,34 @@
+import { buildURL } from '../utils/helpers'
+import BaseExtend from '../extends/base'
+
+class DataEntriesEndpoint extends BaseExtend {
+  constructor(endpoint) {
+    super(endpoint)
+    this.endpoint = 'personal-data/related-data-entries'
+  }
+
+  All(token = null) {
+    const { limit, offset, filter } = this
+
+    const url = buildURL(this.endpoint, {
+      limit,
+      offset,
+      filter
+    })
+
+    return this.request.send(url, 'GET', undefined, token, this)
+  }
+
+  Filter(resourceType, resourceId) {
+    this.filter = {
+      eq: {
+        resource_type: resourceType,
+        resource_id: resourceId
+      }
+    }
+
+    return this
+  }
+}
+
+export default DataEntriesEndpoint

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -45,6 +45,7 @@ import {UserAuthenticationPasswordProfileEndpoint
 } from "./types/user-authentication-password-profile";
 import { MetricsEndpoint } from './types/metrics'
 import { PersonalDataEndpoint } from './types/personal-data'
+import { DataEntriesEndpoint } from './types/data-entries'
 
 export * from './types/config'
 export * from './types/storage'
@@ -99,6 +100,7 @@ export * from './types/pcm-variations'
 export * from './types/pcm-variations-relationships'
 export * from './types/metrics'
 export * from './types/personal-data'
+export * from './types/data-entries'
 
 
 // UMD
@@ -151,6 +153,7 @@ export class Moltin {
   PcmVariationsRelationship: PcmVariationsRelationshipsEndpoint;
   Metrics: MetricsEndpoint
   PersonalData: PersonalDataEndpoint;
+  DataEntries: DataEntriesEndpoint;
 
   Cart(id?: string): CartEndpoint // This optional cart id is super worrying when using the SDK in a node server :/
   constructor(config: Config)

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -43,6 +43,7 @@ import AccountMembershipsEndpoint from './endpoints/account-memberships'
 import PCMVariationsEndpoint from './endpoints/pcm-variations'
 import MetricsEndpoint from './endpoints/metrics'
 import PersonalDataEndpoint from './endpoints/personal-data'
+import DataEntriesEndpoint from './endpoints/data-entry'
 
 import { cartIdentifier, tokenInvalid, getCredentials } from './utils/helpers'
 import CatalogsEndpoint from './endpoints/catalogs'
@@ -87,6 +88,7 @@ export default class Moltin {
     this.Variations = new VariationsEndpoint(config)
     this.PCMVariations = new PCMVariationsEndpoint(config)
     this.PersonalData = new PersonalDataEndpoint(config)
+    this.DataEntries = new DataEntriesEndpoint(config)
     this.AuthenticationRealm = new AuthenticationRealmEndpoint(config)
     this.OidcProfile = new OidcProfileEndpoint(config)
     this.UserAuthenticationInfo = new UserAuthenticationInfoEndpoint(config)

--- a/src/types/data-entries.d.ts
+++ b/src/types/data-entries.d.ts
@@ -1,0 +1,18 @@
+
+import { Identifiable, ResourcePage } from './core'
+
+export interface DataEntryRecord extends Identifiable {
+  type: 'related-data-entry';
+  resource_id: string;
+  resource_type: string;
+}
+
+export interface DataEntriesEndpoint {
+  All(): Promise<ResourcePage<DataEntryRecord>>
+
+  Filter(resourceType: string, resourceId: string): DataEntriesEndpoint
+
+  Limit(value: number): DataEntriesEndpoint
+
+  Offset(value: number): DataEntriesEndpoint
+}


### PR DESCRIPTION
## Type

* ### Feature
  Added support for DataEntries endpoint

## Description

This PR adds types and functions for `/personal-data/related-data-entries` api. This complements functionality that was added for the `/personal-data/logs` api.
