### PR TITLE
fix(Types): Redefined GrantType as a const enum

### DIFF
--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -68,7 +68,7 @@ export interface Config {
 
 export type HttpVerbs = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-export enum GrantType {
+export const enum GrantType {
   ClientCredentials = 'client_credentials',
   Implicit = 'implicit'
 }


### PR DESCRIPTION
## Type

* ### Fix
This redefines GrantType as a `const enum` which fixes 'Cannot read properties of undefined` error.
