### PR TITLE
feat(Config): Add RetryMaxAttempts to config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,8 @@ class Config {
       protocol,
       store_id,
       retryDelay,
-      retryJitter
+      retryJitter,
+      retryMaxAttempts
     } = options
 
     this.application = application
@@ -53,6 +54,7 @@ class Config {
     this.reauth = reauth || true
     this.retryDelay = retryDelay || 1000
     this.retryJitter = retryJitter || 500
+    this.retryMaxAttempts = retryMaxAttempts || 4
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ class Config {
       store_id,
       retryDelay,
       retryJitter,
-      retryMaxAttempts
+      fetchMaxAttempts
     } = options
 
     this.application = application
@@ -54,7 +54,10 @@ class Config {
     this.reauth = reauth || true
     this.retryDelay = retryDelay || 1000
     this.retryJitter = retryJitter || 500
-    this.retryMaxAttempts = retryMaxAttempts || 4
+    this.fetchMaxAttempts =
+      fetchMaxAttempts !== undefined && fetchMaxAttempts !== null
+        ? fetchMaxAttempts
+        : 4
   }
 }
 

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -58,9 +58,8 @@ const fetchRetry = (
   headers,
   requestBody,
   attempt = 1
-) => {
-  const maxAttempts = 4
-  return new Promise((resolve, reject) => {
+) =>
+  new Promise((resolve, reject) => {
     const ver = version || config.version || ''
     config.auth.fetch
       .bind()(`${config.protocol}://${config.host}/${ver}/${uri}`, {
@@ -73,7 +72,7 @@ const fetchRetry = (
         if (response.ok) {
           resolve(response.json)
         }
-        if (attempt !== maxAttempts && response.status === 429) {
+        if (attempt !== config.retryMaxAttempts && response.status === 429) {
           setTimeout(
             () =>
               fetchRetry(
@@ -96,7 +95,6 @@ const fetchRetry = (
       })
       .catch(error => reject(error))
   })
-}
 
 class RequestFactory {
   constructor(config) {

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -72,7 +72,7 @@ const fetchRetry = (
         if (response.ok) {
           resolve(response.json)
         }
-        if (attempt !== config.retryMaxAttempts && response.status === 429) {
+        if (attempt < config.fetchMaxAttempts && response.status === 429) {
           setTimeout(
             () =>
               fetchRetry(

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -37,7 +37,7 @@ export interface ConfigOptions {
   reauth?: Boolean,
   retryDelay?: number
   retryJitter?: number
-  retryMaxAttempts?: number
+  fetchMaxAttempts?: number
 }
 
 export interface Config {
@@ -64,7 +64,7 @@ export interface Config {
   storage_type?: 'cookies' | 'localStorage'
   retryDelay?: number
   retryJitter?: number
-  retryMaxAttempts? number
+  fetchMaxAttempts? number
 
   constructor(options: ConfigOptions): void
 }

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -37,6 +37,7 @@ export interface ConfigOptions {
   reauth?: Boolean,
   retryDelay?: number
   retryJitter?: number
+  retryMaxAttempts?: number
 }
 
 export interface Config {
@@ -63,6 +64,7 @@ export interface Config {
   storage_type?: 'cookies' | 'localStorage'
   retryDelay?: number
   retryJitter?: number
+  retryMaxAttempts? number
 
   constructor(options: ConfigOptions): void
 }

--- a/test/unit/error.ts
+++ b/test/unit/error.ts
@@ -12,8 +12,9 @@ const apiUrl = 'https://api.moltin.com/v2'
 describe('Moltin error handling', () => {
   const Moltin = MoltinGateway({
     client_id: 'XXX',
-    retryDelay: 10, // Reduce retryDelay/retryJitter for retries during testing
-    retryJitter: 1
+    retryDelay: 10, // Reduce retryDelay/retryJitter/retryMaxAttempts for retries during testing
+    retryJitter: 1,
+    retryMaxAttempts: 2 // Minimum amount of retries we need for these tests.
   })
 
   it('should handle a 429 correctly', () => {
@@ -24,7 +25,7 @@ describe('Moltin error handling', () => {
       }
     })
       .get('/products')
-      .times(4)
+      .times(2)
       .reply(429, rateLimitError)
 
     return Moltin.Products.All().catch(error => {

--- a/test/unit/error.ts
+++ b/test/unit/error.ts
@@ -12,9 +12,9 @@ const apiUrl = 'https://api.moltin.com/v2'
 describe('Moltin error handling', () => {
   const Moltin = MoltinGateway({
     client_id: 'XXX',
-    retryDelay: 10, // Reduce retryDelay/retryJitter/retryMaxAttempts for retries during testing
+    retryDelay: 10, // Reduce retryDelay/retryJitter/fetchMaxAttempts for retries during testing
     retryJitter: 1,
-    retryMaxAttempts: 2 // Minimum amount of retries we need for these tests.
+    fetchMaxAttempts: 2 // Minimum amount of fetch attempts we need for these tests.
   })
 
   it('should handle a 429 correctly', () => {


### PR DESCRIPTION
Allows the number of retries when getting status 429 to be configured. The default is 4.

## Type

* ### Feature
  Implements a new feature
## Description

*A brief description of the goals of the pull request.*

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Fixes #

## Notes

*Any additional notes.*
