### PR TITLE
fix: component_products field in product.meta should be optional

### DIFF
--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -56,7 +56,7 @@ export interface ProductResponse extends Identifiable {
         }
       }
     },
-    component_products: {
+    component_products?: {
       [key: string]: {
         display_price: {
           without_tax: FormattedPrice


### PR DESCRIPTION
* ### Fix
Fix to make `component_products` field optional in `product.meta` object
