### PR TITLE
Fix issue while calling ShopperCatalog.Get() method.

### DIFF
--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -272,8 +272,7 @@ class Products extends ShopperCatalogProductsQuery {
 class ShopperCatalogEndpoint extends ShopperCatalogQuery {
   constructor(endpoint) {
     super()
-    const config = { ...endpoint } // Need to clone config so it is only updated in PCM
-    config.version = ''
+    const config = { ...endpoint, version: undefined } // Need to clone config so it is only updated in PCM
     this.Nodes = new Nodes(endpoint)
     this.Hierarchies = new Hierarchies(endpoint)
     this.Products = new Products(endpoint)

--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -281,7 +281,7 @@ class ShopperCatalogEndpoint extends ShopperCatalogQuery {
     this.request = new RequestFactory(config)
   }
 
-  Get({ token = null, additionalHeaders = null }) {
+  Get({ token = null, additionalHeaders = null } = {}) {
     this.call = this.request.send(
       `${this.endpoint}`,
       'GET',

--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -273,6 +273,7 @@ class ShopperCatalogEndpoint extends ShopperCatalogQuery {
   constructor(endpoint) {
     super()
     const config = { ...endpoint } // Need to clone config so it is only updated in PCM
+    config.version = ''
     this.Nodes = new Nodes(endpoint)
     this.Hierarchies = new Hierarchies(endpoint)
     this.Products = new Products(endpoint)


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug


## Description

The call to shopperCatalog.Get() method without any options would throw referenceError.Also, Current implementation is making API call to an invalid endpoint('https://api.moltin.com/v2/catalog').

## Issues

1. Calling Catalog.Get() without customer token
2. Calling API to invalid api endpoint

* Fixes #
1. Add default argument to the method definition (ShopperCatalog.Get().
2. Update config.version in ShopperCatalogClass constructor.

