### PR TITLE
fix: ShopperCatalogResourcePage type added for ShopperCatalogProducts…

### DIFF
--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -14,6 +14,14 @@ export interface ShopperCatalogResource<T> extends Resource<T> {
   }
 }
 
+/** @deprecated Use ShopperCatalogResourcePage instead. Will be removed on next major release. */
+export interface ShopperCatalogResourceList<T> extends ResourceList<T> {
+  included?: {
+    main_images?: File[]
+    files?: File[]
+  }
+}
+
 export interface ShopperCatalogReleaseBase extends Identifiable {
   type: 'catalog-release'
   attributes: {
@@ -41,14 +49,6 @@ export interface ShopperCatalogReleaseBase extends Identifiable {
   }
   links: {
     self: string
-  }
-}
-
-/** @deprecated Use ShopperCatalogResourcePage instead. Will be removed on next major release. */
-export interface ShopperCatalogResourceList<T> extends ResourceList<T> {
-  included?: {
-    main_images?: File[]
-    files?: File[]
   }
 }
 

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -1,4 +1,4 @@
-import type { Resource, ResourcePage } from './core'
+import type { ResourceList, Resource, ResourcePage } from './core'
 import type { ProductResponse } from './catalogs-products'
 import type { Catalog, CatalogFilter } from './catalogs'
 import type { Node } from './nodes'
@@ -44,6 +44,14 @@ export interface ShopperCatalogReleaseBase extends Identifiable {
   }
 }
 
+/** @deprecated Use ShopperCatalogResourcePage instead. Will be removed on next major release. */
+export interface ShopperCatalogResourceList<T> extends ResourceList<T> {
+  included?: {
+    main_images?: File[]
+    files?: File[]
+  }
+}
+
 interface ShopperCatalogQueryableResource<Endpoints, DataType, Filter> {
   Filter(filter: Filter): Endpoints
 
@@ -77,7 +85,7 @@ interface ShopperCatalogResourcePageIncluded {
   component_products?: ProductResponse[]
 }
 
-type ShopperCatalogResourcePage<T> = ResourcePage<T, ShopperCatalogResourcePageIncluded>
+export type ShopperCatalogResourcePage<T> = ResourcePage<T, ShopperCatalogResourcePageIncluded>
 
 export interface ShopperCatalogProductsEndpoint
   extends ShopperCatalogProductsQueryableResource<

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -1,5 +1,5 @@
 import type {
-  ResourceList, Resource
+  ResourceList, Resource, ResourcePage
 } from './core'
 import type { ProductResponse } from './catalogs-products'
 import type { Catalog, CatalogFilter } from './catalogs'
@@ -80,6 +80,14 @@ interface ShopperCatalogProductsQueryableResource<
   With(includes: Include | Include[]): Endpoints
 }
 
+interface ShopperCatalogResourcePageIncluded {
+  main_images?: File[]
+  files?: File[]
+  component_products?: ProductResponse[]
+}
+
+export type ShopperCatalogResourcePage<T> = ResourcePage<T, ShopperCatalogResourcePageIncluded>
+
 export interface ShopperCatalogProductsEndpoint
   extends ShopperCatalogProductsQueryableResource<
       ShopperCatalogProductsEndpoint,
@@ -92,7 +100,7 @@ export interface ShopperCatalogProductsEndpoint
   All(options?: {
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<ProductResponse>>
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 
   Get(options: {
     productId: string

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -1,6 +1,4 @@
-import type {
-  ResourceList, Resource, ResourcePage
-} from './core'
+import type { Resource, ResourcePage } from './core'
 import type { ProductResponse } from './catalogs-products'
 import type { Catalog, CatalogFilter } from './catalogs'
 import type { Node } from './nodes'
@@ -13,13 +11,6 @@ export interface ShopperCatalogResource<T> extends Resource<T> {
     main_images?: File[]
     files?: File[]
     component_products?: ProductResponse[]
-  }
-}
-
-export interface ShopperCatalogResourceList<T> extends ResourceList<T> {
-  included?: {
-    main_images?: File[]
-    files?: File[]
   }
 }
 
@@ -112,13 +103,13 @@ export interface ShopperCatalogProductsEndpoint
     nodeId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<ProductResponse>>
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 
   GetProductsByHierarchy(options: {
     hierarchyId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<ProductResponse>>
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 }
 
 export interface NodesShopperCatalogEndpoint
@@ -132,7 +123,7 @@ export interface NodesShopperCatalogEndpoint
   All(options?: {
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<Node>>
+  }): Promise<ShopperCatalogResourcePage<Node>>
 
   Get(options: {
     nodeId: string
@@ -144,13 +135,13 @@ export interface NodesShopperCatalogEndpoint
     nodeId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<Node>>
+  }): Promise<ShopperCatalogResourcePage<Node>>
 
   GetNodeProducts(options: {
     nodeId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<ProductResponse>>
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 }
 
 export interface HierarchiesShopperCatalogEndpoint
@@ -164,7 +155,7 @@ export interface HierarchiesShopperCatalogEndpoint
   All(options?: {
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<Hierarchy>>
+  }): Promise<ShopperCatalogResourcePage<Hierarchy>>
 
   Get(options: {
     hierarchyId: string
@@ -176,13 +167,13 @@ export interface HierarchiesShopperCatalogEndpoint
     hierarchyId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<Node>>
+  }): Promise<ShopperCatalogResourcePage<Node>>
 
   GetHierarchyNodes(options?: {
     hierarchyId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourceList<Hierarchy>>
+  }): Promise<ShopperCatalogResourcePage<Hierarchy>>
 }
 
 export interface ShopperCatalogEndpoint

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -77,7 +77,7 @@ interface ShopperCatalogResourcePageIncluded {
   component_products?: ProductResponse[]
 }
 
-export type ShopperCatalogResourcePage<T> = ResourcePage<T, ShopperCatalogResourcePageIncluded>
+type ShopperCatalogResourcePage<T> = ResourcePage<T, ShopperCatalogResourcePageIncluded>
 
 export interface ShopperCatalogProductsEndpoint
   extends ShopperCatalogProductsQueryableResource<


### PR DESCRIPTION
`ShopperCatalogProductsEndpoint.All` edpoint return type updated according to thread in D2C project:
https://github.com/elasticpath/d2c-reference-store/pull/18#discussion_r923194066

@field123 

* ### Feature
  Implements a new feature
* ### Fix
  Fixes a bug
* ### Docs
  Documentation only changes
* ### Style
  Changes that **do not** affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* ### Refactor
  A code change that neither fixes a bug nor adds a feature
* ### Performance
  A code change that improves performance
* ### Test
  Adding missing or correcting existing tests
* ### Chore
  Changes to the build process or auxiliary tools and libraries such as documentation generation  

## Description

*A brief description of the goals of the pull request.*

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Fixes #

## Notes

*Any additional notes.*
