### PR TITLE
fix: missing types for GetAllHierarchies

### DIFF
--- a/src/types/catalogs-releases.d.ts
+++ b/src/types/catalogs-releases.d.ts
@@ -1,4 +1,5 @@
-import { Identifiable, Resource, ResourceList } from './core'
+import { Identifiable, Resource, ResourceList, ResourcePage } from './core'
+import { Hierarchy } from './hierarchies'
 
 export interface ReleaseBase extends Identifiable {
   name: string
@@ -29,6 +30,12 @@ export interface CatalogsReleasesEndpoint {
     releaseId: string
     token?: string
   }): Promise<Resource<ReleaseResponse>>
+
+  GetAllHierarchies(options: {
+    catalogId: string
+    releaseId: string
+    token?: string
+  }): Promise<ResourcePage<Hierarchy>>
 
   Create(options: {
     catalogId: string

--- a/src/types/hierarchies.d.ts
+++ b/src/types/hierarchies.d.ts
@@ -2,10 +2,7 @@
  * Products
  * Description: Products are the core resource to any Commerce Cloud project. They can be associated by category, collection, brands, and more.
  */
-import {
-  Identifiable,
-  CrudQueryableResource, ResourceList, ResourcePage
-} from './core'
+import { Identifiable, CrudQueryableResource, ResourcePage } from './core'
 import { NodesEndpoint, Node } from './nodes'
 import { NodeRelationshipsEndpoint } from './node-relationships'
 
@@ -19,6 +16,9 @@ export interface HierarchyBase {
     name: string
     description?: string
     slug?: string
+    created_at?: string
+    updated_at?: string
+    published_at?: string
   }
 }
 
@@ -46,26 +46,32 @@ export interface HierarchyFilter {
 }
 
 type HierarchySort = // TODO
-  | ''
+  ''
 
 type HierarchyInclude = // TODO
-  | ''
+  ''
 
 /**
  * PCM Product Endpoints
  */
 export interface HierarchiesEndpoint
-  extends CrudQueryableResource<Hierarchy,
+  extends CrudQueryableResource<
+    Hierarchy,
     HierarchyBase,
     Partial<HierarchyBase>,
     HierarchyFilter,
     HierarchySort,
-    HierarchyInclude> {
+    HierarchyInclude
+  > {
   endpoint: 'hierarchies'
   Nodes: NodesEndpoint
   Relationships: NodeRelationshipsEndpoint
   Children(id: string, token?: string): Promise<ResourcePage<Node>>
-  Duplicate(hierarchyId: string, body: DuplicateHierarchyBody, token?: string): Promise<Hierarchy>
+  Duplicate(
+    hierarchyId: string,
+    body: DuplicateHierarchyBody,
+    token?: string
+  ): Promise<Hierarchy>
   Limit(value: number): HierarchiesEndpoint
   Offset(value: number): HierarchiesEndpoint
 }


### PR DESCRIPTION
## Type

* ### Feature
 adding types for GetAllHierarchies from catalog releases