### PR TITLE
feat: added request for get products nodes

### DIFF
--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -39,6 +39,17 @@ class PCMEndpoint extends CRUDExtend {
     )
   }
 
+  GetProductNodes(productId) {
+    const { limit, offset } = this
+    return this.request.send(
+      buildURL(`${this.endpoint}/${productId}/nodes`, {
+        limit,
+        offset
+      }),
+      'GET'
+    )
+  }
+
   ImportProducts(file) {
     return this.request.send(`${this.endpoint}/import`, 'POST', file)
   }

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -2,7 +2,12 @@
  * Products
  * Description: Products are the core resource to any Commerce Cloud project. They can be associated by category, collection, brands, and more.
  */
-import { Identifiable, CrudQueryableResource, ResourcePage } from './core'
+import {
+  Identifiable,
+  CrudQueryableResource,
+  ResourcePage,
+  ResourceList
+} from './core'
 import { PcmFileRelationshipEndpoint } from './pcm-file-relationship'
 import { PcmTemplateRelationshipEndpoint } from './pcm-template-relationship'
 import { PcmVariationsRelationshipsEndpoint } from './pcm-variations-relationships'
@@ -140,6 +145,14 @@ export interface PcmProductsEndpoint
    */
 
   GetChildProducts(productId: string): Promise<ResourcePage<PcmProduct>>
+
+  /**
+   * Get Product Nodes
+   * https://documentation.elasticpath.com/commerce-cloud/docs/api/pcm/products/relationships/get-a-products-nodes.html
+   * @param productId - The ID of the product to get the nodes for.
+   * @constructor
+   */
+  GetProductNodes(productId: string): Promise<ResourceList<Node>>
 
   /**
    * Import Products


### PR DESCRIPTION
Couldn't resolve conflicts for https://github.com/moltin/js-sdk/pull/558 so created a new pr and reduced the scope.

https://documentation.elasticpath.com/commerce-cloud/docs/api/pcm/products/relationships/get-a-products-nodes.html

## Type

* ### Feature
  Implements a new feature

* ### Refactor
  A code change that neither fixes a bug nor adds a feature

## Description

* Updates on Catalogs Nodes, Products and Releases interfaces.
* PCM endpoint `GetNodesByProduct` referencing `Get a product's nodes` Postman endpoint.

![image](https://user-images.githubusercontent.com/38511917/140306170-4a7c81ba-6973-4dde-bb27-d6ccc8c6e02c.png)