### PR TITLE
fix!: credentials

### DIFF
--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -113,17 +113,28 @@ class RequestFactory {
       : createAuthRequest(config)
 
     promise
-      .then(({ access_token, refresh_token, expires }) => {
-        if (access_token || refresh_token) {
-          const credentials = {
-            client_id: config.client_id,
-            access_token,
-            expires,
-            ...(refresh_token && { refresh_token })
+      .then(
+        ({
+          access_token,
+          refresh_token,
+          expires,
+          expires_in,
+          identifier,
+          token_type
+        }) => {
+          if (access_token || refresh_token) {
+            const credentials = {
+              access_token,
+              expires,
+              expires_in,
+              identifier,
+              token_type,
+              ...(refresh_token && { refresh_token })
+            }
+            storage.set('moltinCredentials', JSON.stringify(credentials))
           }
-          storage.set('moltinCredentials', JSON.stringify(credentials))
         }
-      })
+      )
       .catch(() => {})
 
     return promise

--- a/src/factories/request.js
+++ b/src/factories/request.js
@@ -124,6 +124,7 @@ class RequestFactory {
         }) => {
           if (access_token || refresh_token) {
             const credentials = {
+              client_id: config.client_id,
               access_token,
               expires,
               expires_in,

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -52,7 +52,7 @@ import { PersonalDataEndpoint } from './types/personal-data'
 import { DataEntriesEndpoint } from './types/data-entries'
 import { ErasureRequestsEndpoint } from './types/erasure-requests'
 import { PriceBookPriceModifierEndpoint } from './types/price-book-price-modifiers'
-import { AccountMembershipSettingsEndpoint } from './types/account-membership-settings';
+import { AccountMembershipSettingsEndpoint } from './types/account-membership-settings'
 
 export * from './types/config'
 export * from './types/storage'
@@ -124,7 +124,7 @@ export class Moltin {
   cartId?: string
   request: RequestFactory
   storage: StorageFactory
-  credentials: AuthenticateResponseBody
+  credentials: () => AuthenticateResponseBody | null
   Products: ProductsEndpoint
   PCM: PcmProductsEndpoint
   Catalogs: CatalogsEndpoint

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -106,9 +106,8 @@ export default class Moltin {
     this.AccountMembershipSettings = new AccountMembershipSettingsEndpoint(
       config
     )
-    this.UserAuthenticationPasswordProfile = new UserAuthenticationPasswordProfileEndpoint(
-      config
-    )
+    this.UserAuthenticationPasswordProfile =
+      new UserAuthenticationPasswordProfileEndpoint(config)
     this.Metrics = new MetricsEndpoint(config)
   }
 

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -187,7 +187,7 @@ export interface HierarchiesShopperCatalogEndpoint
     hierarchyId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourcePage<Hierarchy>>
+  }): Promise<ShopperCatalogResourcePage<Node>>
 }
 
 export interface ShopperCatalogEndpoint

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -237,7 +237,7 @@ export function getCredentials(storage) {
   return JSON.parse(storage.get('moltinCredentials'))
 }
 
-export function tokenInvalid({ storage, client_id, reauth }) {
+export function tokenInvalid({ storage, reauth }) {
   const credentials = getCredentials(storage)
 
   const handleInvalid = message => {
@@ -253,9 +253,6 @@ export function tokenInvalid({ storage, client_id, reauth }) {
 
   if (!credentials.access_token)
     return handleInvalid('Token status: credentials missing access_token')
-
-  if (credentials.client_id !== client_id)
-    return handleInvalid('Token status: client_id mismatch')
 
   if (Math.floor(Date.now() / 1000) >= credentials.expires)
     return handleInvalid('Token status: credentials expired')

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -237,7 +237,7 @@ export function getCredentials(storage) {
   return JSON.parse(storage.get('moltinCredentials'))
 }
 
-export function tokenInvalid({ storage, reauth }) {
+export function tokenInvalid({ storage, client_id, reauth }) {
   const credentials = getCredentials(storage)
 
   const handleInvalid = message => {
@@ -253,6 +253,9 @@ export function tokenInvalid({ storage, reauth }) {
 
   if (!credentials.access_token)
     return handleInvalid('Token status: credentials missing access_token')
+
+  if (credentials.client_id !== client_id)
+    return handleInvalid('Token status: client_id mismatch')
 
   if (Math.floor(Date.now() / 1000) >= credentials.expires)
     return handleInvalid('Token status: credentials expired')

--- a/test/unit/promotions.ts
+++ b/test/unit/promotions.ts
@@ -1,6 +1,9 @@
 import { assert } from 'chai'
 import nock from 'nock'
-import { gateway as MoltinGateway } from '../../src/moltin'
+import {
+  gateway as MoltinGateway,
+  MemoryStorageFactory
+} from '../../src/moltin'
 import {
   auth,
   promotionsArray as promotions,
@@ -12,7 +15,8 @@ const accessToken = 'testaccesstoken'
 
 describe('Moltin promotions', () => {
   const Moltin = MoltinGateway({
-    custom_authenticator: () => auth(accessToken)
+    custom_authenticator: () => auth(accessToken),
+    storage: new MemoryStorageFactory()
   })
 
   it('should return an array of promotions', () => {

--- a/test/unit/variations.ts
+++ b/test/unit/variations.ts
@@ -1,6 +1,9 @@
 import { assert } from 'chai'
 import nock from 'nock'
-import { gateway as MoltinGateway } from '../../src/moltin'
+import {
+  gateway as MoltinGateway,
+  MemoryStorageFactory
+} from '../../src/moltin'
 import {
   variationsArray as variations,
   optionsArray as options,
@@ -13,8 +16,11 @@ const accessToken = 'testaccesstoken'
 
 describe('Moltin variations', () => {
   const Moltin = MoltinGateway({
-    custom_authenticator: () => auth(accessToken)
+    custom_authenticator: () => auth(accessToken),
+    storage: new MemoryStorageFactory()
   })
+
+  console.log('expected auth header: ', `Bearer ${accessToken}`)
 
   it('should return an a single variation', () => {
     nock(apiUrl, {


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

BREAKING CHANGE:
Removed client_id from `moltinCredentials` credentials data in local storage. Use `Moltin.config.clientId` instead

Updated the response type of `Moltin.credentials` to properly reflect that it can return `null` if the localstorage entry has not yet been created e.g. unauthenticated.

Updated return type of GetHierarchyNodes method
