### PR TITLE
fix: correct GetHierarchyNodes return type

### DIFF
--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -181,7 +181,7 @@ export interface HierarchiesShopperCatalogEndpoint
     hierarchyId: string
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
-  }): Promise<ShopperCatalogResourcePage<Hierarchy>>
+  }): Promise<ShopperCatalogResourcePage<Node>>
 }
 
 export interface ShopperCatalogEndpoint


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

Should return Node instead of Hierarchy
