### PR TITLE
fix: import correct node version

### DIFF
--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -15,6 +15,7 @@ import { PcmMainImageRelationshipEndpoint } from './pcm-main-image-relationship'
 import { PcmJobsEndpoint } from './pcm-jobs'
 import { File } from './file'
 import { Locales } from './locales'
+import { Node } from './nodes'
 
 /**
  * Core PCM Product Base Interface


### PR DESCRIPTION
It was using the default typescript node type

## Type

* ### Fix
  Fixes a bug

## Description

Types were using the default typescript node type instead of our epcc node type
