### PR TITLE
feat: original_display_price field added to ProductResponse interface

### DIFF
--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -41,11 +41,10 @@ export interface ProductResponse extends Identifiable {
     catalog_source?: 'pcm'
     pricebook_id?: string
     display_price?: {
-      without_tax: {
-        amount: number
-        currency: string
-        formatted: string
-      }
+      without_tax: FormattedPrice
+    }
+    original_display_price?: {
+      without_tax: FormattedPrice
     }
     variation_matrix?: MatrixObject
     variations?: CatalogsProductVariation[]


### PR DESCRIPTION
[## Type](https://elasticpath.atlassian.net/browse/MT-13264)
`original_display_price` is required to handle the previous price in Products response.