### PR TITLE
feat: added include items and tax_items for cart endpoint

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -16,7 +16,14 @@ class CartEndpoint extends BaseExtend {
   }
 
   Get() {
-    return this.request.send(`${this.endpoint}/${this.cartId}`, 'GET')
+    const { includes } = this
+
+    return this.request.send(
+        buildURL(`${this.endpoint}/${this.cartId}`, {
+          includes,
+        }),
+        'GET'
+    )
   }
 
   Items() {

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -133,8 +133,20 @@ export interface CartItemObject {
   code?: string
 }
 
+export type CartInclude =
+    | 'items'
+    | 'tax_items'
+
+interface CartQueryableResource <
+    R,
+    F,
+    S,
+    > extends QueryableResource<Cart, F, S, CartInclude> {
+  With(includes: CartInclude | CartInclude[]): CartEndpoint
+}
+
 export interface CartEndpoint
-  extends QueryableResource<Cart, never, never, never> {
+  extends CartQueryableResource<Cart, never, never> {
   endpoint: 'carts'
   cartId: string
 


### PR DESCRIPTION
## Type

* ### Feature

## Description

added include items and tax_items for cart endpoint 

- [include docs tax items](https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-orders/carts/cart-items/get-cart-items.html#query-parameters) 
- [include docs items](https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-orders/carts/get-a-cart.html#query-parameters)
