### PR TITLE
feat: added tax item includes and items includes types.

### DIFF
--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -28,6 +28,8 @@ export interface CreateCartObject {
  * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/cart-items/tax-items/index.html
  */
 export interface ItemTaxObject {
+  id: string
+  type: 'tax-item'
   name: string
   jurisdiction: string
   code: string
@@ -119,6 +121,9 @@ export interface CartItemsResponse {
       updated_at: string
       expires_at: string
     }
+  },
+  included?: {
+    tax_items?: ItemTaxObject[]
   }
 }
 
@@ -145,6 +150,14 @@ interface CartQueryableResource <
   With(includes: CartInclude | CartInclude[]): CartEndpoint
 }
 
+export interface ResourceIncluded<R, I = never> extends Resource<R> {
+  included?: I
+}
+
+export interface CartIncluded {
+  items: CartItem[]
+}
+
 export interface CartEndpoint
   extends CartQueryableResource<Cart, never, never> {
   endpoint: 'carts'
@@ -154,7 +167,7 @@ export interface CartEndpoint
    * Get a Cart by reference
    * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/get-a-cart.html
    */
-  Get(): Promise<Resource<Cart>>
+  Get(): Promise<ResourceIncluded<Cart, CartIncluded>>
 
   /**
    * Get Cart Items

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -28,12 +28,15 @@ export interface CreateCartObject {
  * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-checkout/carts/cart-items/tax-items/index.html
  */
 export interface ItemTaxObject {
-  id: string
   type: 'tax-item'
   name: string
   jurisdiction: string
   code: string
   rate: number
+}
+
+export interface ItemTaxObjectResponse extends ItemTaxObject{
+  id: string
 }
 
 /**
@@ -123,7 +126,7 @@ export interface CartItemsResponse {
     }
   },
   included?: {
-    tax_items?: ItemTaxObject[]
+    tax_items?: ItemTaxObjectResponse[]
   }
 }
 
@@ -401,7 +404,7 @@ export interface CartEndpoint
   AddItemTax(
     itemId: string,
     taxData: ItemTaxObject
-  ): Promise<Resource<ItemTaxObject>>
+  ): Promise<Resource<ItemTaxObjectResponse>>
 
   /**
    * Update a Tax Item
@@ -414,7 +417,7 @@ export interface CartEndpoint
     itemId: string,
     taxItemId: string,
     taxData: ItemTaxObject
-  ): Promise<Resource<ItemTaxObject>>
+  ): Promise<Resource<ItemTaxObjectResponse>>
 
   /**
    * Delete a Tax Item

--- a/test/unit/cart.ts
+++ b/test/unit/cart.ts
@@ -1007,7 +1007,8 @@ describe('Moltin cart', () => {
       code: 'CALI',
       rate: 0.0775,
       jurisdiction: 'CALIFORNIA',
-      name: 'California Tax'
+      name: 'California Tax',
+      type: 'tax-item'
     }
 
     // Intercept the API request
@@ -1034,7 +1035,8 @@ describe('Moltin cart', () => {
       code: 'CALI',
       rate: 0.0775,
       jurisdiction: 'CALIFORNIA',
-      name: 'California Tax'
+      name: 'California Tax',
+      type: 'tax-item'
     }
 
     // Intercept the API request


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description

Tax items now have a required `type` property as it's required by the api when creating a tax item. I've also added a response version of the object to reflect that the id is present.

