### PR TITLE
fix: do manual wrapping of body

### DIFF
--- a/src/endpoints/orders.js
+++ b/src/endpoints/orders.js
@@ -12,7 +12,9 @@ class OrdersEndpoint extends BaseExtend {
   }
 
   Payment(id, body) {
-    return this.request.send(`${this.endpoint}/${id}/payments`, 'POST', body)
+    return this.request.send(`${this.endpoint}/${id}/payments`, 'POST', {
+      data: body,
+    }, null, null, false)
   }
 
   Confirm(orderId, transactionId, body) {


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

### Payment requests with options had undefined data property on request object

buildRequestBody checks for an options property and if it's present expects a props to be on a data property. This is not the case with payment requests.

When an options property is present on a payment request the data field in the request becomes undefined. e.g. { data: undefined, options: {...} }

Manual wrapping and then telling the request to not wrap the data prevents this.

