### PR TITLE
feat!: Constrained types for Payment endpoint.

### DIFF
--- a/src/types/util.d.ts
+++ b/src/types/util.d.ts
@@ -3,3 +3,12 @@ export type WithOptional<T, K extends keyof T> = Omit<T, K> &
 
 export type WithRequired<T, K extends keyof T> = Pick<T, K> &
   Partial<Omit<T, K>>
+
+/**
+ * XOR using conditional types
+ * https://github.com/Microsoft/TypeScript/issues/14094#issuecomment-373782604
+ */
+export type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
+export type XOR<T, U> = T | U extends object
+  ? (Without<T, U> & U) | (Without<U, T> & T)
+  : T | U


### PR DESCRIPTION
## Type

* ### Feature
## Description

BREAKING CHANGE: Types for data being passed to gateway.Order.Payment have been constrained further to help make it more clear what options are required by which payment gateway in the devs IDE.

Each payment type is now part of a discriminated union the key property being `gateway`. This pass was done using the current documentation as the source of truth if anything is missing let us know.
