### PR TITLE
feat(application keys): adds Application Keys endpoint

### DIFF
--- a/src/endpoints/application-keys.js
+++ b/src/endpoints/application-keys.js
@@ -1,0 +1,38 @@
+import CRUDExtend from '../extends/crud'
+import { buildURL } from '../utils/helpers'
+
+class ApplicationKeysEndpoint extends CRUDExtend {
+  constructor(endpoint) {
+      super(endpoint)
+      this.endpoint = 'application-keys'
+  }
+
+  Create(body) {
+      return this.request.send(this.endpoint, 'POST', body)
+  }
+
+  All(token = null, headers = {}) {
+    const { limit, offset, filter } = this
+
+    this.call = this.request.send(
+      buildURL(this.endpoint, {
+        limit,
+        offset,
+        filter
+      }),
+      'GET',
+      undefined,
+      token,
+      this,
+      headers
+    )
+
+    return this.call
+  }
+
+  Delete(id) {
+    return this.request.send(`${this.endpoint}/${id}`, 'DELETE')
+  }  
+}
+
+export default ApplicationKeysEndpoint

--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -53,6 +53,7 @@ import { DataEntriesEndpoint } from './types/data-entries'
 import { ErasureRequestsEndpoint } from './types/erasure-requests'
 import { PriceBookPriceModifierEndpoint } from './types/price-book-price-modifiers'
 import { AccountMembershipSettingsEndpoint } from './types/account-membership-settings'
+import { ApplicationKeysEndpoint } from './types/application-keys'
 
 export * from './types/config'
 export * from './types/storage'
@@ -116,6 +117,7 @@ export * from './types/user-authentication-info'
 export * from './types/user-authentication-password-profile'
 export * from './types/locales'
 export * from './types/extensions'
+export * from './types/application-keys'
 
 // UMD
 export as namespace moltin
@@ -171,6 +173,7 @@ export class Moltin {
   DataEntries: DataEntriesEndpoint
   ErasureRequests: ErasureRequestsEndpoint
   PriceBookPriceModifier: PriceBookPriceModifierEndpoint
+  ApplicationKeys: ApplicationKeysEndpoint
 
   Cart(id?: string): CartEndpoint // This optional cart id is super worrying when using the SDK in a node server :/
   constructor(config: Config)

--- a/src/moltin.js
+++ b/src/moltin.js
@@ -46,6 +46,7 @@ import PersonalDataEndpoint from './endpoints/personal-data'
 import DataEntriesEndpoint from './endpoints/data-entry'
 import AccountMembershipSettingsEndpoint from './endpoints/account-membership-settings'
 import ErasureRequestsEndpoint from './endpoints/erasure-requests'
+import ApplicationKeysEndpoint from './endpoints/application-keys'
 
 import {cartIdentifier, tokenInvalid, getCredentials, resolveCredentialsStorageKey} from './utils/helpers'
 import CatalogsEndpoint from './endpoints/catalogs'
@@ -110,6 +111,7 @@ export default class Moltin {
     this.UserAuthenticationPasswordProfile =
       new UserAuthenticationPasswordProfileEndpoint(config)
     this.Metrics = new MetricsEndpoint(config)
+    this.ApplicationKeys = new ApplicationKeysEndpoint(config)
   }
 
   // Expose `Cart` class on Moltin class

--- a/src/types/application-keys.d.ts
+++ b/src/types/application-keys.d.ts
@@ -1,0 +1,30 @@
+import { CrudQueryableResource } from '../../dist/moltin'
+import { Identifiable, Resource, ResourcePage } from './core'
+
+export interface ApplicationKeyBase {
+  name: string
+  type: 'application_key'
+}
+
+export interface ApplicationKey extends ApplicationKeyBase, Identifiable {
+    id: string
+    client_id: string
+    client_secret?: string
+    meta: {
+      timestamps: {
+        created_at: string
+        updated_at: string
+      }
+    }
+}
+export interface ApplicationKeyResponse extends Resource<ApplicationKey> {
+  links: {
+    self: string
+  }
+}
+
+export interface ApplicationKeysEndpoint {
+  All(): Promise<ResourcePage<ApplicationKey>>
+  Create(body: ApplicationKeyBase): Promise<ApplicationKeyResponse>
+  Delete(id: string): void
+}

--- a/src/types/application-keys.d.ts
+++ b/src/types/application-keys.d.ts
@@ -1,4 +1,3 @@
-import { CrudQueryableResource } from '../../dist/moltin'
 import { Identifiable, Resource, ResourcePage } from './core'
 
 export interface ApplicationKeyBase {


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description

Adds application keys endpoint to the SDK. This endpoint allows creation of store keys that can be utilized by any user in the store and it not tied to a user. 

`client_secret` is optional param as it is only visble on creation, GET calls should not return `client_secret`

