### PR TITLE
feat: catalog product children

### DIFF
--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -267,6 +267,30 @@ class Products extends ShopperCatalogProductsQuery {
       additionalHeaders
     )
   }
+
+  GetProductChildren({
+    productId,
+    token = null,
+    additionalHeaders = null
+  }) {
+    const { limit, offset, filter, includes } = this
+
+    return this.request.send(
+      buildURL(`catalog/${this.endpoint}/${productId}/relationships/children`, {
+        limit,
+        offset,
+        filter,
+        includes
+      }),
+      'GET',
+      undefined,
+      token,
+      undefined,
+      false,
+      undefined,
+      additionalHeaders
+    )
+  }
 }
 
 class ShopperCatalogEndpoint extends ShopperCatalogQuery {

--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -147,6 +147,22 @@ class Products extends CRUDExtend {
       token
     )
   }
+
+  GetCatalogProductChildren({
+    catalogId,
+    releaseId,
+    productId,
+    token = null
+  }) {
+    return this.request.send(
+        `catalogs/${catalogId}/releases/${releaseId}/${
+            this.endpoint
+        }/${productId}/relationships/children`,
+        'GET',
+        undefined,
+        token
+    )
+  }
 }
 
 class Releases extends CRUDExtend {

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -124,6 +124,12 @@ export interface ShopperCatalogProductsEndpoint
     token?: string
     additionalHeaders?: ShopperCatalogAdditionalHeaders
   }): Promise<ShopperCatalogResourcePage<ProductResponse>>
+
+  GetProductChildren(options: {
+    productId: string
+    token?: string
+    additionalHeaders?: ShopperCatalogAdditionalHeaders
+  }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 }
 
 export interface NodesShopperCatalogEndpoint

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -157,4 +157,11 @@ export interface CatalogsProductsEndpoint {
     releaseId: string
     token?: string
   }): Promise<ResourcePage<PcmProduct>>
+
+  GetCatalogProductChildren(options: {
+    catalogId: string
+    releaseId: string
+    productId: string
+    token?: string
+  }): Promise<ResourcePage<PcmProduct>>
 }


### PR DESCRIPTION
## Type

* ### Feature
add /children/ endpoint in catalog view

## Description

ShopperCatalog: `moltin.ShopperCatalog.Products.GetProductChildren({productId})`

Catalogs: `moltin.Catalogs.Products.GetCatalogProductChildren({catalogId, releaseId, productId})`
