### PR TITLE
Fix/bulkadd options add all or nothing default should be true

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -82,7 +82,7 @@ class CartEndpoint extends BaseExtend {
   BulkAdd(body) {
     return this.request.send(`${this.endpoint}/${this.cartId}/items`, 'POST', {
       data: body,
-      options: { add_all_or_nothing: false }
+      options: { add_all_or_nothing: true }
     })
   }
 


### PR DESCRIPTION
## Type

* ### Fix
  It fixes a contradictory default value field 

## Description

*The PR fixes the default value field for `BulkAdd`. As mentioned in the [Documentation](https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-orders/carts/bulk-add-to-cart.html#__docusaurus), the `add_all_or_nothing` field should be `true`*

