### PR TITLE
Added support for getting products by release

### DIFF
--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -163,6 +163,15 @@ class Products extends CRUDExtend {
         token
     )
   }
+
+  GetProductsInCatalogRelease({ catalogId, releaseId, token = null }) {
+    return this.request.send(
+      `catalogs/${catalogId}/releases/${releaseId}/products`,
+      'GET',
+      undefined,
+      token
+    )
+  }
 }
 
 class Releases extends CRUDExtend {

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -164,4 +164,10 @@ export interface CatalogsProductsEndpoint {
     productId: string
     token?: string
   }): Promise<ResourcePage<PcmProduct>>
+
+  GetProductsInCatalogRelease(options: {
+    catalogId: string
+    releaseId: string
+    token?: string
+  }): Promise<ResourcePage<ProductResponse>>
 }


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description

This PR is adding support for fetching all products from a catalog release
https://documentation.elasticpath.com/commerce-cloud/docs/api/pcm/catalogs/releases/products/get-all-products-in-a-release.html

