### PR TITLE
fix: Confirm endpoint body changed to which is in docs

### DIFF
--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -451,15 +451,15 @@ export interface OrdersEndpoint
 
   /**
    * Confirm payment intent
-   * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/payments/transactions.html#post-confirm-payment-intent
+   * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/payments/paying-for-an-order/elastic-path-payments-stripe.html#confirmation---post-confirm-the-security-validation-succeeded
    * @param orderId - The ID of the order.
    * @param transactionId - The ID of the transaction you want to confirm.
-   * @param body - The body of the order.
+   * @param body - The empty data object.
    */
   Confirm(
     orderId: string,
     transactionId: string,
-    body: ConfirmPaymentBody
+    body: { data: {} }
   ): Promise<ConfirmPaymentResponse>
 
   /**

--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -459,7 +459,7 @@ export interface OrdersEndpoint
   Confirm(
     orderId: string,
     transactionId: string,
-    body: { data: {} }
+    body: {}
   ): Promise<ConfirmPaymentResponse>
 
   /**

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -226,16 +226,18 @@ describe('Moltin orders', () => {
         Authorization: 'Bearer a550d8cbd4a4627013452359ab69694cd446615a'
       }
     })
-      .post('/orders/order-2/transactions/1/confirm', {})
+      .post('/orders/order-2/transactions/1/confirm', {
+        data: {}
+      })
       .reply(201, {
         status: 'complete'
       })
 
-    return Moltin.Orders.Confirm(orders[1].id, transactionId, {
-      data: {}
-    }).then(response => {
-      assert.propertyVal(response, 'status', 'complete')
-    })
+    return Moltin.Orders.Confirm(orders[1].id, transactionId, {}).then(
+      response => {
+        assert.propertyVal(response, 'status', 'complete')
+      }
+    )
   })
 
   it('should update an order', () => {

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -130,15 +130,17 @@ describe('Moltin orders', () => {
         Authorization: 'Bearer a550d8cbd4a4627013452359ab69694cd446615a'
       }
     })
-        .get('/orders/order-1?include=account,account_member')
-        .reply(200, orders[0])
+      .get('/orders/order-1?include=account,account_member')
+      .reply(200, orders[0])
 
-    return Moltin.Orders.With(['account', 'account_member']).Get(orders[0].id).then((response:any) => {
-      assert.propertyVal(response, 'id', 'order-1')
-      assert.propertyVal(response, 'status', 'complete')
-      assert.lengthOf(response.included.accounts, 1)
-      assert.lengthOf(response.included.account_members, 1)
-    })
+    return Moltin.Orders.With(['account', 'account_member'])
+      .Get(orders[0].id)
+      .then((response: any) => {
+        assert.propertyVal(response, 'id', 'order-1')
+        assert.propertyVal(response, 'status', 'complete')
+        assert.lengthOf(response.included.accounts, 1)
+        assert.lengthOf(response.included.account_members, 1)
+      })
   })
 
   it('should return a single order using a JWT', () => {
@@ -225,20 +227,14 @@ describe('Moltin orders', () => {
       }
     })
       .post('/orders/order-2/transactions/1/confirm', {
-        data: {
-          gateway: 'purchase',
-          payment: 'test',
-          method: 'payment_intents'
-        }
+        data: {}
       })
       .reply(201, {
         status: 'complete'
       })
 
     return Moltin.Orders.Confirm(orders[1].id, transactionId, {
-      gateway: 'purchase',
-      payment: 'test',
-      method: 'payment_intents'
+      data: {}
     }).then(response => {
       assert.propertyVal(response, 'status', 'complete')
     })

--- a/test/unit/orders.ts
+++ b/test/unit/orders.ts
@@ -226,9 +226,7 @@ describe('Moltin orders', () => {
         Authorization: 'Bearer a550d8cbd4a4627013452359ab69694cd446615a'
       }
     })
-      .post('/orders/order-2/transactions/1/confirm', {
-        data: {}
-      })
+      .post('/orders/order-2/transactions/1/confirm', {})
       .reply(201, {
         status: 'complete'
       })


### PR DESCRIPTION
We need to call the `Cconfirm` endpoint to confirm the EP Stripe payment.
The "Confirm" endpoint was described with the wrong `body`. After some investigations, I assume that body should be { data: {} }

Links with described flow:
https://elasticpath-software.slack.com/archives/C03L8QEUG5A/p1661810465608449?thread_ts=1661552938.535809&cid=C03L8QEUG5A

https://elasticpath-software.slack.com/archives/G0193Q8HNFJ/p1661966012599799?thread_ts=1661957241.000449&cid=G0193Q8HNFJ

