### PR TITLE
feat: hierarchy attach/detach nodes

### DIFF
--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -53,6 +53,14 @@ class PCMEndpoint extends CRUDExtend {
   ImportProducts(file) {
     return this.request.send(`${this.endpoint}/import`, 'POST', file)
   }
+  
+  AttachNodes(body) {
+    return this.request.send(`${this.endpoint}/attach_nodes`, 'POST', body)
+  }
+
+  DetachNodes(body) {
+    return this.request.send(`${this.endpoint}/detach_nodes`, 'POST', body)
+  }
 }
 
 export default PCMEndpoint

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -102,6 +102,14 @@ export interface PcmProductResponse {
 
 export type PcmProductsResponse = ResourcePage<PcmProduct, PcmProductsIncluded>
 export type PcmProductUpdateBody = Partial<PcmProductBase> & Identifiable
+
+/**
+ * PCM Product nodes attachment body
+ */
+export interface PcmProductAttachmentBody {
+  filter: string
+  node_ids: string[]
+}
 /**
  * PCM Product Endpoints
  */
@@ -162,4 +170,18 @@ export interface PcmProductsEndpoint
    * @constructor
    */
   ImportProducts(file: FormData): Promise<{}>
+
+  /**
+   * Attach Nodes
+   * @param body - filter and node id's
+   * @constructor
+   */
+  AttachNodes(body: PcmProductAttachmentBody): Promise<{}>
+
+  /**
+   * Detach Nodes
+   * @param body - filter and node id's
+   * @constructor
+   */
+  DetachNodes(body: PcmProductAttachmentBody): Promise<{}>
 }


### PR DESCRIPTION
## Type

* ### Feature
feat: hierarchy attach/detach nodes

## Description
This allows you to pass in a filter from the product list screen and use whatever the products are returned for node assignment.


