### PR TITLE
Added pagination for GetProductsInCatalogRelease()

### DIFF
--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -165,8 +165,16 @@ class Products extends CRUDExtend {
   }
 
   GetProductsInCatalogRelease({ catalogId, releaseId, token = null }) {
+    const { limit, offset, includes, sort, filter } = this
+
     return this.request.send(
-      `catalogs/${catalogId}/releases/${releaseId}/products`,
+      buildURL(`catalogs/${catalogId}/releases/${releaseId}/products`, {
+        includes,
+        sort,
+        limit,
+        offset,
+        filter
+      }),
       'GET',
       undefined,
       token


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature
## Description

Added pagination for GetProductsInCatalogRelease() method. This allows users to chain it like:
```
  const products = await gateway.Catalogs.Products
    .Offset(x)
    .Limit(y)
    .GetProductsInCatalogRelease({});
```
