### PR TITLE
fix: 'payment' removed from ManualPayment interface

### DIFF
--- a/src/types/order.d.ts
+++ b/src/types/order.d.ts
@@ -322,7 +322,7 @@ export interface ElasticPathStripePayment extends StripePaymentBase {
  * Manual Payments
  */
 
-export interface ManualPayment extends PaymentBase {
+export interface ManualPayment {
   method: PurchasePaymentMethod | AuthorizePaymentMethod
   gateway: 'manual'
   amount?: number


### PR DESCRIPTION
https://elasticpath.atlassian.net/browse/MT-14072

`ManualPayment` interface updated:
- removed extending from `PaymentBase` interface as long as `payment` field is excessive