### PR TITLE
feat(Filters):  add support for 'in' operator in ElasticPath filter

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -90,10 +90,13 @@ function formatFilterString(type, filter) {
     const value = filter[key]
     let queryString = `${key},${value}`
 
-    if (typeof value === 'object')
+    if (Array.isArray(value)) {
+      queryString = `${key},${value.join(',')}`
+    } else if (typeof value === 'object') {
       queryString = Object.keys(value).map(
         attr => `${key}.${attr},${value[attr]}`
       )
+    }
 
     return `${type}(${queryString})`
   })

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -14,7 +14,7 @@ import {
   resetProps,
   getCredentials,
   tokenInvalid,
-  tryParseJSON,
+  tryParseJSON
 } from '../../src/utils/helpers'
 
 import LocalStorageFactory from '../../src/factories/local-storage'
@@ -167,6 +167,12 @@ describe('Format filter string', () => {
     const res = formatFilterString('eq', { user: { name: 'Test' } })
 
     expect(res).to.equal('eq(user.name,Test)')
+  })
+
+  it('should return a valid filter string for "in" operator', () => {
+    const res = formatFilterString('in', { sku: ['prod12', 'prod34','prod56'] })
+    
+    expect(res).to.equal('in(sku,prod12,prod34,prod56)')
   })
 })
 
@@ -419,7 +425,10 @@ describe('Parsing body JSON', () => {
   })
 
   it('should parse non-empty object', () => {
-    expect(tryParseJSON('{ "a": 123, "b": "str" }', 'fallback')).to.deep.equal({ a: 123, b: 'str' })
+    expect(tryParseJSON('{ "a": 123, "b": "str" }', 'fallback')).to.deep.equal({
+      a: 123,
+      b: 'str'
+    })
   })
 
   it('should parse complex object', () => {
@@ -428,7 +437,7 @@ describe('Parsing body JSON', () => {
       status: 500,
       errors: [
         { code: 123, message: 'Server error' },
-        { code: 456, message: 'Another error' },
+        { code: 456, message: 'Another error' }
       ]
     }
 


### PR DESCRIPTION
## Type

* ### Fix
  Fix logic to add support for 'in' operator in filters

## Description
The current logic for creating query parameters for Elastic Path filters doesn't work with the 'in' operator.

## Notes
`const filter = {
  "in": {
    "sku":  ["prod123", "prod456"]
  }
}
`
If the above filter variable is passed to the existing `formatFilterString()` function implementation, it returns an invalid output like `in(sku.0,prod123,sku.1,prod456)`.
This fix supports processing an array of values, resulting in the following output.
`in(sku, "prod123","prod456")`

*Any additional notes.*
`Sample url: https://api.moltin.com/pcm/products?page[limit]=25&filter=in(sku,prod123,prod456)`