### PR TITLE
Update catalogs-products for include tax prices

### DIFF
--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -45,9 +45,11 @@ export interface ProductResponse extends Identifiable {
     pricebook_id?: string
     display_price?: {
       without_tax: FormattedPrice
+      with_tax: FormattedPrice
     }
     original_display_price?: {
       without_tax: FormattedPrice
+      with_tax: FormattedPrice
     }
     variation_matrix?: MatrixObject
     variations?: CatalogsProductVariation[]


### PR DESCRIPTION
## Type

Update pricing models

* ### Feature

Add includes tax to display_price and original_display_price to support EMEA VAT based countries. 

## Description

*Add in missing meta for pricing in catalog product view.*

