### PR TITLE
feat: added pricebook_ids field to catalogs base type

### DIFF
--- a/src/types/catalogs.d.ts
+++ b/src/types/catalogs.d.ts
@@ -7,11 +7,11 @@ import { CatalogsNodesEndpoint } from './catalogs-nodes'
 import { CatalogsProductsEndpoint } from './catalogs-products'
 import { CatalogsReleasesEndpoint } from './catalogs-releases'
 import { CatalogsRulesEndpoint } from './catalogs-rules'
-import { ShopperCatalogReleaseBase } from "./catalog";
+import { ShopperCatalogReleaseBase } from './catalog'
 
 /**
- * Core PCM Product Base Interface
- * For custom flows, extend this interface
+ * Catalog Base interface
+ *  pricebook_id OR pricebook_ids must be present, but never both or neither
  */
 export interface CatalogBase {
   type: 'catalog'
@@ -19,7 +19,8 @@ export interface CatalogBase {
     name: string
     description?: string
     hierarchy_ids: string[]
-    pricebook_id: string
+    pricebook_id?: string
+    pricebook_ids?: { priority: number; id: string }[]
     created_at?: string
     updated_at?: string
   }
@@ -52,19 +53,26 @@ export type CatalogUpdateBody = Partial<CatalogBase> & Identifiable
 
 export interface CatalogsEndpoint
   extends CrudQueryableResource<
-      Catalog,
-      CatalogBase,
-      CatalogUpdateBody,
-      CatalogFilter,
-      CatalogSort,
-      CatalogInclude
-    > {
+    Catalog,
+    CatalogBase,
+    CatalogUpdateBody,
+    CatalogFilter,
+    CatalogSort,
+    CatalogInclude
+  > {
   endpoint: 'catalogs'
   Nodes: CatalogsNodesEndpoint
   Products: CatalogsProductsEndpoint
   Releases: CatalogsReleasesEndpoint
   Rules: CatalogsRulesEndpoint
-  GetCatalogReleases(catalogId: string, token?: string): Promise<ResourceList<ShopperCatalogReleaseBase>>
-  DeleteCatalogRelease(catalogId: string, releaseId: string, token?: string): Promise<void>
+  GetCatalogReleases(
+    catalogId: string,
+    token?: string
+  ): Promise<ResourceList<ShopperCatalogReleaseBase>>
+  DeleteCatalogRelease(
+    catalogId: string,
+    releaseId: string,
+    token?: string
+  ): Promise<void>
   DeleteAllCatalogReleases(catalogId: string, token?: string): Promise<void>
 }


### PR DESCRIPTION
## Type

* ### Feature
  Added pricebook_ids to catalogs base type. Made that and the pricebook_id property optional, as they can either be included, but never both or neither of them.

## Description

See documentation for more info on the pricebook_ids and pricebook_id fields: https://documentation.elasticpath.com/commerce-cloud/docs/api/pcm/catalogs/configure/create-a-catalog.html#body

## Dependencies

*Other PRs or builds that this PR depends on.*

## Issues

*A list of issues closed by this PR.*

* Part of this ticket: https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/121
