### PR TITLE
feat: Add optional header parameter to the addProduct function in cart module

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -43,7 +43,14 @@ class CartEndpoint extends BaseExtend {
     return this.call
   }
 
-  AddProduct(productId, quantity = 1, data = {}, isSku = false, token = null) {
+  AddProduct(
+    productId,
+    quantity = 1,
+    data = {},
+    isSku = false,
+    token = null,
+    additionalHeaders = {}
+  ) {
     const body = buildCartItemData(productId, quantity, 'cart_item', {}, isSku)
 
     return this.request.send(
@@ -53,7 +60,11 @@ class CartEndpoint extends BaseExtend {
         ...body,
         ...data
       },
-      token
+      token,
+      null,
+      true,
+      null,
+      additionalHeaders
     )
   }
 

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -169,6 +169,12 @@ export interface CartIncluded {
   items: CartItem[]
 }
 
+export interface CartAdditionalHeaders {
+  'EP-Context-Tag'?: string
+  'EP-Channel'?: string
+  'X-MOLTIN-CURRENCY'?: string
+}
+
 export interface CartEndpoint
   extends CartQueryableResource<Cart, never, never> {
   endpoint: 'carts'
@@ -201,7 +207,7 @@ export interface CartEndpoint
     data?: any,
     isSku?: boolean,
     token?: string,
-    additionalHeaders?: any
+    additionalHeaders?: CartAdditionalHeaders
   ): Promise<CartItemsResponse>
 
   /**
@@ -251,7 +257,8 @@ export interface CartEndpoint
   AddProduct(
     productId: string,
     quantity?: number,
-    data?: any
+    data?: any,
+    additionalHeaders?: CartAdditionalHeaders
   ): Promise<CartItemsResponse>
 
   RemoveAllItems(): Promise<CartItemsResponse>

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -200,7 +200,8 @@ export interface CartEndpoint
     quantity?: number,
     data?: any,
     isSku?: boolean,
-    token?: string
+    token?: string,
+    additionalHeaders?: any
   ): Promise<CartItemsResponse>
 
   /**


### PR DESCRIPTION
* ### Fix
  **Added optional header parameter to addProduct function in cart module**  

## Description

As of now, currency is set at gateway level during Motlin gateway initialization. If the gateway is initialized based on a singleton pattern, it's difficult to reuse the same gateway across multiple apis from a storefront that handles multiple currencies. One solution would be to use a request scoped gateway initialization which is an expensive approach as the number of requests gets higher. An alternative way is to pass currencies as optional parameters with addProduct or similar APIS which makes it more flexible to use.

## Dependencies
N/A

##Issue Link
https://github.com/moltin/js-sdk/issues/769