### PR TITLE
feat: Update node product and catalog node types

### DIFF
--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -51,12 +51,14 @@ class Nodes extends CRUDExtend {
   }) {
     const { limit, offset, sort } = this
     return this.request.send(
-      buildURL(`catalogs/${catalogId}/releases/${releaseId}/${this.endpoint
-        }/${nodeId}/relationships/children`, {
-        sort,
-        limit,
-        offset
-      }),
+      buildURL(
+        `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${nodeId}/relationships/children`,
+        {
+          sort,
+          limit,
+          offset
+        }
+      ),
       'GET',
       undefined,
       token
@@ -117,9 +119,7 @@ class Products extends CRUDExtend {
 
   GetProduct({ catalogId, releaseId, productId, token = null }) {
     return this.request.send(
-      `catalogs/${catalogId}/releases/${releaseId}/${
-        this.endpoint
-      }/${productId}`,
+      `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}`,
       'GET',
       undefined,
       token
@@ -129,19 +129,23 @@ class Products extends CRUDExtend {
   GetCatalogNodeProducts({ catalogId, releaseId, nodeId, token = null }) {
     const { limit, offset, includes, sort, filter } = this
     return this.request.send(
-      buildURL(`catalogs/${catalogId}/releases/${releaseId}/nodes/${nodeId}/relationships/${this.endpoint
-        }`, {
-        includes,
-        sort,
-        limit,
-        offset,
-        filter
-      }),
+      buildURL(
+        `catalogs/${catalogId}/releases/${releaseId}/nodes/${nodeId}/relationships/${this.endpoint}`,
+        {
+          includes,
+          sort,
+          limit,
+          offset,
+          filter
+        }
+      ),
       'GET',
       undefined,
       token
     )
   }
+
+  // TODO: Endpoint doesn't exist - replace / remove
 
   GetProductsByNode({ nodeId, token = null }) {
     return this.request.send(
@@ -169,16 +173,9 @@ class Products extends CRUDExtend {
     )
   }
 
-  GetCatalogProductChildren({
-    catalogId,
-    releaseId,
-    productId,
-    token = null
-  }) {
+  GetCatalogProductChildren({ catalogId, releaseId, productId, token = null }) {
     return this.request.send(
-      `catalogs/${catalogId}/releases/${releaseId}/${
-        this.endpoint
-      }/${productId}/relationships/children`,
+      `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}/relationships/children`,
       'GET',
       undefined,
       token
@@ -235,10 +232,12 @@ class Releases extends CRUDExtend {
 
     return this.request.send(
       buildURL(
-        `catalogs/${catalogId}/${this.endpoint}/${releaseId}/hierarchies`, {
-        limit,
-        offset
-      }),
+        `catalogs/${catalogId}/${this.endpoint}/${releaseId}/hierarchies`,
+        {
+          limit,
+          offset
+        }
+      ),
       'GET',
       undefined,
       token
@@ -250,8 +249,7 @@ class Releases extends CRUDExtend {
       `catalogs/${catalogId}/${this.endpoint}`,
       'POST',
       body,
-      token,
-      
+      token
     )
   }
 }
@@ -350,7 +348,7 @@ class CatalogsEndpoint extends CRUDExtend {
       `${this.endpoint}/${catalogId}/releases`,
       'GET',
       undefined,
-      token,
+      token
     )
   }
 

--- a/src/types/catalogs-nodes.d.ts
+++ b/src/types/catalogs-nodes.d.ts
@@ -11,6 +11,7 @@ export interface NodeBaseResponse extends Identifiable {
     slug: string
     status: string
     updated_at: string
+    curated_products?: string[]
   }
   relationships: {
     children: {
@@ -52,7 +53,7 @@ export interface CatalogsNodesEndpoint {
   Get(options: {
     nodeId: string
     token?: string
-  }): Promise<Resource<NodeBaseResponse>>
+  }): Promise<Resource<NodesResponse>>
 
   GetNodeChildren(options: {
     nodeId: string

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -2,11 +2,11 @@ import type { Identifiable, Resource, ResourceList, ResourcePage } from './core'
 import type { ProductFilter } from './product'
 import type { PcmProduct, ProductComponents } from './pcm'
 import type { MatrixObject, Option, Variation } from './variations'
-import type {Extensions} from "./extensions";
+import type { Extensions } from './extensions'
 import type { FormattedPrice } from './price'
 
-
-export interface CatalogsProductVariation extends Omit<Variation, 'relationships' | 'options'> {
+export interface CatalogsProductVariation
+  extends Omit<Variation, 'relationships' | 'options'> {
   options: Omit<Option, 'modifiers'>[]
 }
 
@@ -36,9 +36,9 @@ export interface ProductResponse extends Identifiable {
     store_id: string
     translations: string[]
     updated_at: string
-    weight: string,
+    weight: string
     extensions?: Extensions
-  };
+  }
   meta: {
     catalog_id?: string
     catalog_source?: 'pcm'
@@ -59,22 +59,22 @@ export interface ProductResponse extends Identifiable {
           [key: string]: number
         }
       }
-    },
+    }
     component_products?: {
       [key: string]: {
         display_price: {
           without_tax: FormattedPrice
-        },
+        }
         price: {
           [key: string]: {
             includes_tax: boolean
             amount: number
           }
-        },
+        }
         pricebook_id: string
       }
     }
-  };
+  }
   relationships: {
     categories: {
       id: string
@@ -119,6 +119,12 @@ export interface ProductResponse extends Identifiable {
   }
 }
 
+export interface NodeProductResponse extends ProductResponse {
+  attributes: ProductResponse['attributes'] & {
+    curated_product?: boolean
+  }
+}
+
 export interface CatalogsProductsEndpoint {
   endpoint: 'products'
 
@@ -147,8 +153,9 @@ export interface CatalogsProductsEndpoint {
     releaseId: string
     nodeId: string
     token?: string
-  }): Promise<ResourceList<ProductResponse>>
+  }): Promise<ResourceList<NodeProductResponse>>
 
+  // TODO: Endpoint doesn't exist - replace / remove
   GetProductsByNode(options: {
     nodeId: string
     token?: string

--- a/src/types/node-relationships.d.ts
+++ b/src/types/node-relationships.d.ts
@@ -23,7 +23,9 @@ export interface CreateChildrenSortOrderBody extends Identifiable {
 }
 
 export interface NodeProduct extends PcmProduct {
-  curated_product?: boolean
+  attributes: PcmProduct['attributes'] & {
+    curated_product?: boolean
+  }
 }
 
 export interface NodeRelationshipsEndpoint {

--- a/src/types/node-relationships.d.ts
+++ b/src/types/node-relationships.d.ts
@@ -1,9 +1,5 @@
-import {
-  ResourcePage,
-  Resource,
-  Identifiable
-} from "./core";
-import { PcmProduct } from "./pcm";
+import { ResourcePage, Resource, Identifiable } from './core'
+import { PcmProduct } from './pcm'
 
 export interface NodeRelationshipBase {
   type: 'product'
@@ -20,10 +16,14 @@ export interface NodeRelationshipParent {
 }
 
 export interface CreateChildrenSortOrderBody extends Identifiable {
-      "type": "node",
-      "meta": {
-        "sort_order": number
-      }
+  type: 'node'
+  meta: {
+    sort_order: number
+  }
+}
+
+export interface NodeProduct extends PcmProduct {
+  curated_product?: boolean
 }
 
 export interface NodeRelationshipsEndpoint {
@@ -54,7 +54,7 @@ export interface NodeRelationshipsEndpoint {
     hierarchyId: string
     nodeId: string
     token?: string
-  }): Promise<ResourcePage<PcmProduct>>
+  }): Promise<ResourcePage<NodeProduct>>
 
   ChangeParent(options: {
     hierarchyId: string


### PR DESCRIPTION
## Type

 * ### Feature

## Description
Gitlab issue:[ CM: Allow users to curate a node's products](https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/90)

- Addition of the 'curated_product' optional boolean field for node products
- Addition of 'curated_products' optional string array for catalogs nodes
