### PR TITLE
Feature/request scoped headers and merge cart

### DIFF
--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -141,13 +141,18 @@ class CartEndpoint extends BaseExtend {
     return this.request.send(`${this.endpoint}/${this.cartId}/items`, 'DELETE')
   }
 
-  UpdateItem(itemId, quantity, data = {}) {
+  UpdateItem(itemId, quantity, data = {}, additionalHeaders = {}) {
     const body = buildCartItemData(itemId, quantity)
 
     return this.request.send(
       `${this.endpoint}/${this.cartId}/items/${itemId}`,
       'PUT',
-      { ...body, ...data }
+      { ...body, ...data },
+      null,
+      null,
+      true,
+      null,
+      additionalHeaders
     )
   }
 

--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -211,7 +211,12 @@ class CartEndpoint extends BaseExtend {
     )
   }
 
-  Checkout(customer, billing_address, shipping_address = billing_address) {
+  Checkout(
+    customer,
+    billing_address,
+    shipping_address = billing_address,
+    additionalHeaders = {}
+  ) {
     const body = buildCartCheckoutData(
       customer,
       billing_address,
@@ -221,7 +226,12 @@ class CartEndpoint extends BaseExtend {
     return this.request.send(
       `${this.endpoint}/${this.cartId}/checkout`,
       'POST',
-      body
+      body,
+      null,
+      null,
+      true,
+      null,
+      additionalHeaders
     )
   }
 

--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -240,6 +240,23 @@ class CartEndpoint extends BaseExtend {
     )
   }
 
+  Merge(cartId, token, options = {}) {
+    const body = {
+      type: 'cart_items',
+      cart_id: `${cartId}`
+    }
+
+    return this.request.send(
+      `${this.endpoint}/${this.cartId}/items`,
+      'POST',
+      {
+        data: body,
+        ...(options && { options })
+      },
+      token
+    )
+  }
+
   Delete() {
     return this.request.send(`${this.endpoint}/${this.cartId}`, 'DELETE')
   }

--- a/src/endpoints/cart.js
+++ b/src/endpoints/cart.js
@@ -185,6 +185,13 @@ class CartEndpoint extends BaseExtend {
     )
   }
 
+  BulkAddItemTax(body, options) {
+    return this.request.send(`${this.endpoint}/${this.cartId}/taxes`, 'POST', {
+      data: body,
+      ...(options && { options })
+    })
+  }
+
   UpdateItemTax(itemId, taxItemId, taxData) {
     const body = Object.assign(taxData, {
       type: 'tax_item'

--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -104,16 +104,24 @@ class Products extends CRUDExtend {
       `catalogs/${this.endpoint}`,
       'GET',
       undefined,
-      token
+      token,
+      undefined,
+      true,
+      null,
+      additionalHeaders
     )
   }
 
-  Get({ productId, token = null }) {
+  Get({ productId, token = null, additionalHeaders = {} }) {
     return this.request.send(
       `catalogs/${this.endpoint}/${productId}`,
       'GET',
       undefined,
-      token
+      token,
+      undefined,
+      true,
+      null,
+      additionalHeaders
     )
   }
 
@@ -122,7 +130,11 @@ class Products extends CRUDExtend {
       `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}`,
       'GET',
       undefined,
-      token
+      token,
+      undefined,
+      true,
+      null,
+      additionalHeaders
     )
   }
 
@@ -152,7 +164,11 @@ class Products extends CRUDExtend {
       `catalogs/nodes/${nodeId}/relationships/${this.endpoint}`,
       'GET',
       undefined,
-      token
+      token,
+      undefined,
+      true,
+      null,
+      additionalHeaders
     )
   }
 

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -8,6 +8,7 @@ import { Resource, QueryableResource } from './core'
 import { Address } from './address'
 import { Price, FormattedPrice } from './price'
 import { Order } from './order'
+import { PcmProductResponse } from './pcm'
 
 export interface CheckoutCustomer {
   id: string
@@ -143,6 +144,9 @@ export interface BulkAddOptions {
   add_all_or_nothing: boolean
 }
 
+export interface MergeCartOptions {
+  add_all_or_nothing: boolean
+}
 export interface CartItemObject {
   type: string
   name?: string
@@ -495,6 +499,21 @@ export interface CartEndpoint
     additionalHeaders?: CartAdditionalHeaders
   ): Promise<Resource<Order>>
 
+  /**
+   * Merge
+   * Description: Allows to merge two carts. Moves the cart items from one cart to another.
+   * If both the cart items are same, the cart items quantity will be increased
+   * DOCS: https://elasticpath.dev/docs/carts/cart-items/merging-carts.html
+   * @param cartId the cart Id of the cart to be merged.
+   * @param token the customer token of the cart to whom it is associated or to be associated with
+   * @param options When true, if an error occurs for any item, no items are added to the cart. When false, valid items are added to the cart and the items with errors are reported in the response. Default is true
+   */
+
+  Merge(
+    cartId: string,
+    token?: string,
+    options?: MergeCartOptions
+  ): Promise<PcmProductResponse[]>
   /**
    * Delete a Cart
    * Description: You can easily remove all items from a cart.

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -490,7 +490,8 @@ export interface CartEndpoint
   Checkout(
     customer: string | CheckoutCustomer | CheckoutCustomerObject,
     billingAddress: Partial<Address>,
-    shippingAddress?: Partial<Address>
+    shippingAddress?: Partial<Address>,
+    additionalHeaders?: CartAdditionalHeaders
   ): Promise<Resource<Order>>
 
   /**

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -298,7 +298,8 @@ export interface CartEndpoint
   UpdateItem(
     itemId: string,
     quantity: number,
-    customData?: any
+    customData?: any,
+    additionalHeaders?: CartAdditionalHeaders
   ): Promise<CartItemsResponse>
 
   /**

--- a/src/types/cart.d.ts
+++ b/src/types/cart.d.ts
@@ -154,6 +154,22 @@ export interface CartItemObject {
   code?: string
 }
 
+export interface CartTaxItemObject {
+  type: string
+  name: string
+  jurisdiction: string
+  code: string
+  rate: number
+  relationships: {
+    item: {
+      data: {
+        type: string
+        id: string
+      }
+    }
+  }
+}
+
 export type CartInclude = 'items' | 'tax_items'
 
 interface CartQueryableResource<R, F, S>
@@ -429,6 +445,17 @@ export interface CartEndpoint
     taxData: ItemTaxObject
   ): Promise<Resource<ItemTaxObjectResponse>>
 
+  /**
+   * Bulk Add Items tax to Cart
+   * Description: When you enable the bulk add feature, a shopper can add an array of items to their cart in one action, rather than adding each item one at a time.
+   * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-orders/carts/bulk-add-to-cart.html
+   * @param data Cart items or custom items
+   * @param options Optional config object for add to cart behaviour
+   */
+  BulkAddItemTax(
+    data: CartTaxItemObject[],
+    options?: BulkAddOptions
+  ): Promise<CartTaxItemObject[]>
   /**
    * Update a Tax Item
    * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/carts-and-orders/carts/cart-items/tax-items/update-a-tax-item.html

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -79,6 +79,8 @@ type ShopperCatalogProductsInclude =
 interface ShopperCatalogAdditionalHeaders {
   'EP-Context-Tag'?: string
   'EP-Channel'?: string
+  'X-MOLTIN-LANGUAGE'?: string
+  'X-MOLTIN-CURRENCY'?: string
 }
 
 interface ShopperCatalogProductsQueryableResource<

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -134,11 +134,15 @@ export interface CatalogsProductsEndpoint {
 
   Filter(filter: ProductFilter): CatalogsProductsEndpoint
 
-  All(options: { token?: string }): Promise<ResourceList<ProductResponse>>
+  All(options: {
+    token?: string
+    additionalHeaders?: any
+  }): Promise<ResourceList<ProductResponse>>
 
   Get(options: {
     productId: string
     token?: string
+    additionalHeaders?: any
   }): Promise<Resource<ProductResponse>>
 
   GetProduct(options: {
@@ -146,6 +150,7 @@ export interface CatalogsProductsEndpoint {
     releaseId: string
     productId: string
     token?: string
+    additionalHeaders?: any
   }): Promise<Resource<ProductResponse>>
 
   GetCatalogNodeProducts(options: {
@@ -159,6 +164,7 @@ export interface CatalogsProductsEndpoint {
   GetProductsByNode(options: {
     nodeId: string
     token?: string
+    additionalHeaders?: any
   }): Promise<ResourceList<ProductResponse>>
 
   GetCatalogProducts(options: {


### PR DESCRIPTION
## Feature

* ### Feature
 Mering Carts, Bulk Add Tax Items and Request scoped headers in cart and product

* ### Docs
https://elasticpath.dev/docs/carts/cart-items/merging-carts

## Description

A shopper can have one cart and can merge it with another cart. The item from the cart moves to the other cart and if the cart items are the same then the quantity of the products will increase. The bulk add item feature is also added  in the feature. Also added the fix for requested scoped headers in cart and product api

* Fixes #
Update the type of ShopperCatalogAdditionalHeaders to get language and currency as optional header parameter
Add request scoped header as a parameter to the cart checkout api
Add request scoped header as a parameter to the cart updateItem api

