### PR TITLE
fix: Update Node request body type

### DIFF
--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -50,6 +50,11 @@ export interface Node extends Identifiable, NodeBase {
   }
 }
 
+export type UpdateNodeBody = Omit<NodeBase, 'relationships' | 'attributes'> &
+  Identifiable & {
+    attributes: Partial<NodeBase['attributes']>
+  }
+
 export interface NodeFilter {
   // TODO
 }
@@ -87,7 +92,7 @@ export interface NodesEndpoint {
   Update(options: {
     hierarchyId: string
     nodeId: string
-    body: Identifiable & NodeBase
+    body: UpdateNodeBody
     token?: string
   }): Promise<Resource<Node>>
 


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description
**This MR is part of the work required for the 'CM: Curated Node Products' ticket**
- Updated the Hierarchies.Nodes.Update({hiearchyId, nodeId, body}) 'body' type to be more accurate.

The 'type' and 'id' fields are required in the request body but the 'attributes' object's properties are optional. The 'relationships' object is irrelevant in the node update request body.

Docs: https://elasticpath.dev/docs/pxm-hierarchies/nodes-api/update-a-hierarchy-node#body
