### PR TITLE
feat: added support for configure and in filter

### DIFF
--- a/src/endpoints/catalog.js
+++ b/src/endpoints/catalog.js
@@ -207,6 +207,25 @@ class Products extends ShopperCatalogProductsQuery {
     )
   }
 
+  Configure({
+    productId,
+    selectedOptions,
+    token = null,
+    additionalHeaders = null
+  }) {
+    return this.request.send(
+      `catalog/${this.endpoint}/${productId}/configure`,
+      'POST',
+      {
+        selected_options: selectedOptions
+      },
+      token,
+      undefined,
+      true,
+      additionalHeaders
+    )
+  }
+
   Get({ productId, token = null, additionalHeaders = null }) {
     const { includes } = this
 

--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -117,6 +117,17 @@ export interface ShopperCatalogProductsEndpoint
     additionalHeaders?: ShopperCatalogAdditionalHeaders
   }): Promise<ShopperCatalogResourcePage<ProductResponse>>
 
+  Configure(options: {
+    token?: string
+    additionalHeaders?: ShopperCatalogAdditionalHeaders
+    productId: string
+    selectedOptions: {
+      [key: string]: {
+        [key: string]: number
+      }
+    }
+  })
+
   Get(options: {
     productId: string
     token?: string

--- a/src/types/file.d.ts
+++ b/src/types/file.d.ts
@@ -70,6 +70,9 @@ export interface FileFilter {
     height?: number
     file_size?: number
   }
+  in?: {
+    id?: string[]
+  }
 }
 
 /**
@@ -81,12 +84,12 @@ export interface FileFilter {
  */
 export interface FileEndpoint
   extends CrudQueryableResource<
-      File,
-      FileBase,
-      never,
-      FileFilter,
-      never,
-      never
-    > {
+    File,
+    FileBase,
+    never,
+    FileFilter,
+    never,
+    never
+  > {
   endpoint: 'file'
 }


### PR DESCRIPTION
## added support for `configure` for product bundle components on Shopper Product endpoint.

This enables implicit token users to get pricing and configuration for selected component options.

e.g. /catalog/products/14edd744-c615-4a33-a2c2-df999bbb5103/configure

example use:

```
gateway.ShopperCatalog.Products.Configure({
    productId: '14edd744-c615-4a33-a2c2-df999bbb5103',
    selectedOptions: {
      plants: {
        'a158ffa0-5d16-4325-8dcc-be8acd55eecf': 1
      },
      pots: {
        'fc520b37-a709-4032-99b3-8d4ecc990027': 1
      },
      tools: {
        '1cc7f871-1071-4908-a79d-633adc56044a': 1,
        '7ffe107d-c5bd-4de4-b8f0-a58d90cb3cd3': 1
      }
    }
  })
```

## added support for `in` filter on Files endpoint

e.g. in(id,4b97cee1-70ea-4d97-8d46-9c441c3317de,2b435629-28d3-4555-9ce1-204a2f72b412)

example use:

```
gateway.Files.Filter({
    in: {
      id: [
        '4b97cee1-70ea-4d97-8d46-9c441c3317de',
        '2b435629-28d3-4555-9ce1-204a2f72b412'
      ]
    }
  }).All()
```
