### PR TITLE
fix: add missing return type for shopper product configure endpoint

### DIFF
--- a/src/types/catalog.d.ts
+++ b/src/types/catalog.d.ts
@@ -126,7 +126,7 @@ export interface ShopperCatalogProductsEndpoint
         [key: string]: number
       }
     }
-  })
+  }): Promise<ShopperCatalogResource<ProductResponse>>
 
   Get(options: {
     productId: string


### PR DESCRIPTION
add missing return type for shopper product configure endpoint

Previously was untyped and returning `any`, should be returning `Promise<ShopperCatalogResource<ProductResponse>>`
