### PR TITLE
fix: Duplicate Hierarchy endpoint

### DIFF
--- a/src/endpoints/hierarchies.js
+++ b/src/endpoints/hierarchies.js
@@ -31,7 +31,7 @@ class HierarchiesEndpoint extends CRUDExtend {
 
   Duplicate(hierarchyId, body, token = null) {
     return this.request.send(
-      `${this.endpoint}/${hierarchyId}/duplicate`,
+      `${this.endpoint}/${hierarchyId}/duplicate_job`,
       'POST',
       body,
       token

--- a/src/types/hierarchies.d.ts
+++ b/src/types/hierarchies.d.ts
@@ -41,6 +41,7 @@ export interface DuplicateHierarchyBody {
   attributes: {
     name?: string
     description?: string
+    include_products?: boolean
   }
 }
 


### PR DESCRIPTION
## Type

* ### Fix
 
 Update Duplicate Hierarchy endpoint to `/hierarchies/:hierarchyId/duplicate_job`.

Added `attributes.include_products` field in the Body of the request.