### PR TITLE
fix: add missing customer filter properties

### DIFF
--- a/src/types/customer.d.ts
+++ b/src/types/customer.d.ts
@@ -39,10 +39,28 @@ export interface CustomerFilter {
   eq?: {
     name?: string
     email?: string
+    created_at?: string
+    updated_at?: string
   }
   like?: {
     name?: string
     email?: string
+  }
+  ge?: {
+    created_at?: string
+    updated_at?: string
+  }
+  gt?: {
+    created_at?: string
+    updated_at?: string
+  }
+  le?: {
+    created_at?: string
+    updated_at?: string
+  }
+  lt?: {
+    created_at?: string
+    updated_at?: string
   }
 }
 


### PR DESCRIPTION
## Type

* ### Fix
  Fixes a bug

## Description

as per the [docs](https://elasticpath.dev/docs/commerce-cloud/customer-management/customer-managment-api/get-all-customers#filtering) the following fields are missing from the CustomerFilter type
