### PR TITLE
fix: Corrected build child job response and removed unused endpoint

### DIFF
--- a/src/moltin.d.ts
+++ b/src/moltin.d.ts
@@ -157,7 +157,6 @@ export class Moltin {
   Customers: CustomersEndpoint
   Inventories: InventoryEndpoint
   Jobs: JobEndpoint
-  PcmJobs: PcmJobsEndpoint
   Files: FileEndpoint
   Flows: FlowEndpoint
   Fields: FieldsEndpoint

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -141,7 +141,7 @@ export interface PcmProductAttachmentResponse {
     nodes_not_found: string[]
   }
 }
-export type BuildChildProductsJobResponse = Identifiable & PcmJobBase
+export type BuildChildProductsJob = Identifiable & PcmJobBase
 
 /**
  * PCM Product Endpoints
@@ -179,7 +179,7 @@ export interface PcmProductsEndpoint
    * @param productId - The ID of the base product to build the child products for.
    * @constructor
    */
-  BuildChildProducts(productId: string): Promise<BuildChildProductsJobResponse>
+  BuildChildProducts(productId: string): Promise<Resource<BuildChildProductsJob>>
 
   /**
    * Get Child Products


### PR DESCRIPTION
## Type

* ### Fix

## Description

Updated build child products response  by wrapping it around the Resource interface and removed the pcm jobs endpoint from moltin.d.ts
