### PR TITLE
!feat: Optional variation meta field 

### DIFF
--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -23,7 +23,7 @@ import {
 
   export interface PCMVariation extends Identifiable, PCMVariationBase {
     type: 'product-variation'
-    meta: {
+    meta?: {
       options?: PCMVariationMetaOption[]
       owner: 'organization' | 'store'
     }


### PR DESCRIPTION
…e-organisation support variations

## Type

* ### Fix

## Description

BREAKING CHANGE: Turn variation meta field into optional to support pre-organization variations