### PR TITLE
feat!: Added instance within GetCatalogProducts method & type fixes 

### DIFF
--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -99,33 +99,8 @@ class Products extends CRUDExtend {
     this.endpoint = 'products'
   }
 
-  All({ token = null }) {
-    return this.request.send(
-      `catalogs/${this.endpoint}`,
-      'GET',
-      undefined,
-      token,
-      undefined,
-      true,
-      null,
-      additionalHeaders
-    )
-  }
 
-  Get({ productId, token = null, additionalHeaders = {} }) {
-    return this.request.send(
-      `catalogs/${this.endpoint}/${productId}`,
-      'GET',
-      undefined,
-      token,
-      undefined,
-      true,
-      null,
-      additionalHeaders
-    )
-  }
-
-  GetProduct({ catalogId, releaseId, productId, token = null }) {
+  GetCatalogReleaseProduct({ catalogId, releaseId, productId, token = null }) {
     return this.request.send(
       `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}`,
       'GET',
@@ -133,48 +108,12 @@ class Products extends CRUDExtend {
       token,
       undefined,
       true,
-      null,
-      additionalHeaders
+      null
     )
   }
 
-  GetCatalogNodeProducts({ catalogId, releaseId, nodeId, token = null }) {
+  GetAllCatalogReleaseProducts({ catalogId, releaseId, token = null }) {
     const { limit, offset, includes, sort, filter } = this
-    return this.request.send(
-      buildURL(
-        `catalogs/${catalogId}/releases/${releaseId}/nodes/${nodeId}/relationships/${this.endpoint}`,
-        {
-          includes,
-          sort,
-          limit,
-          offset,
-          filter
-        }
-      ),
-      'GET',
-      undefined,
-      token
-    )
-  }
-
-  // TODO: Endpoint doesn't exist - replace / remove
-
-  GetProductsByNode({ nodeId, token = null }) {
-    return this.request.send(
-      `catalogs/nodes/${nodeId}/relationships/${this.endpoint}`,
-      'GET',
-      undefined,
-      token,
-      undefined,
-      true,
-      null,
-      additionalHeaders
-    )
-  }
-
-  GetCatalogProducts({ catalogId, releaseId, token = null }) {
-    const { limit, offset, includes, sort, filter } = this
-
     return this.request.send(
       buildURL(`catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}`, {
         includes,
@@ -190,12 +129,70 @@ class Products extends CRUDExtend {
     )
   }
 
-  GetCatalogProductChildren({ catalogId, releaseId, productId, token = null }) {
+  GetCatalogReleaseProductChildren({ catalogId, releaseId, productId, token = null }) {
+    const { limit, offset, includes, sort, filter } = this
     return this.request.send(
-      `catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}/relationships/children`,
+      buildURL(`catalogs/${catalogId}/releases/${releaseId}/${this.endpoint}/${productId}/relationships/children`, {
+        includes,
+        sort,
+        limit,
+        offset,
+        filter
+      }),
       'GET',
       undefined,
-      token
+      token,
+      this
+    )
+  }
+
+  GetCatalogReleaseNodeProducts({
+    catalogId,
+    releaseId,
+    nodeId,
+    token = null
+  }) {
+    const { limit, offset, includes, sort, filter } = this
+    return this.request.send(
+      buildURL(
+        `catalogs/${catalogId}/releases/${releaseId}/nodes/${nodeId}/relationships/${this.endpoint}`,
+        {
+          includes,
+          sort,
+          limit,
+          offset,
+          filter
+        }
+      ),
+      'GET',
+      undefined,
+      token,
+      this
+    )
+  }
+
+  GetCatalogReleaseHierarchyProducts({
+    catalogId,
+    releaseId,
+    hierarchyId,
+    token = null
+  }) {
+    const { limit, offset, includes, sort, filter } = this
+    return this.request.send(
+      buildURL(
+        `catalogs/${catalogId}/releases/${releaseId}/hierarchies/${hierarchyId}/relationships/${this.endpoint}`,
+        {
+          includes,
+          sort,
+          limit,
+          offset,
+          filter
+        }
+      ),
+      'GET',
+      undefined,
+      token,
+      this
     )
   }
 

--- a/src/endpoints/catalogs.js
+++ b/src/endpoints/catalogs.js
@@ -185,7 +185,8 @@ class Products extends CRUDExtend {
       }),
       'GET',
       undefined,
-      token
+      token,
+      this
     )
   }
 
@@ -198,6 +199,10 @@ class Products extends CRUDExtend {
     )
   }
 
+  /**
+   * @deprecated The method should not be used. Instead, use
+   * @function GetCatalogProducts
+   */
   GetProductsInCatalogRelease({ catalogId, releaseId, token = null }) {
     const { limit, offset, includes, sort, filter } = this
 

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -1,4 +1,4 @@
-import type { Identifiable, Resource, ResourceList, ResourcePage } from './core'
+import type { Identifiable, Resource, ResourcePage } from './core'
 import type { PcmProduct, ProductComponents } from './pcm'
 import type { MatrixObject, Option, Variation } from './variations'
 import type { Extensions } from './extensions'
@@ -172,14 +172,14 @@ export interface CatalogsProductsEndpoint {
     releaseId: string
     nodeId: string
     token?: string
-  }): Promise<ResourceList<NodeProductResponse>>
+  }): Promise<ResourcePage<NodeProductResponse>>
 
   GetCatalogReleaseHierarchyProducts(options: {
     catalogId: string
     releaseId: string
     hierarchyId: string
     token?: string
-  }): Promise<ResourceList<PcmProduct>>
+  }): Promise<ResourcePage<PcmProduct>>
 
   /**
    * @deprecated The method should not be used. Instead, use

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -1,5 +1,4 @@
 import type { Identifiable, Resource, ResourceList, ResourcePage } from './core'
-import type { ProductFilter } from './product'
 import type { PcmProduct, ProductComponents } from './pcm'
 import type { MatrixObject, Option, Variation } from './variations'
 import type { Extensions } from './extensions'
@@ -37,6 +36,7 @@ export interface ProductResponse extends Identifiable {
     translations: string[]
     updated_at: string
     weight: string
+    manufacturer_part_num?: string
     extensions?: Extensions
   }
   meta: {
@@ -125,6 +125,18 @@ export interface NodeProductResponse extends ProductResponse {
   }
 }
 
+export interface CatalogReleaseProductFilterAttributes {
+  name?: string
+  slug?: string
+  sku?: string
+  manufacturer_part_num?: string
+  upc_ean?: string
+}
+export interface CatalogReleaseProductFilter {
+  eq?: CatalogReleaseProductFilterAttributes
+  in?: CatalogReleaseProductFilterAttributes
+}
+
 export interface CatalogsProductsEndpoint {
   endpoint: 'products'
 
@@ -132,7 +144,7 @@ export interface CatalogsProductsEndpoint {
 
   Offset(value: number): CatalogsProductsEndpoint
 
-  Filter(filter: ProductFilter): CatalogsProductsEndpoint
+  Filter(filter: CatalogReleaseProductFilter): CatalogsProductsEndpoint
 
   All(options: {
     token?: string
@@ -179,7 +191,10 @@ export interface CatalogsProductsEndpoint {
     productId: string
     token?: string
   }): Promise<ResourcePage<PcmProduct>>
-
+  /**
+   * @deprecated The method should not be used. Instead, use
+   * @function GetCatalogProducts
+   */
   GetProductsInCatalogRelease(options: {
     catalogId: string
     releaseId: string

--- a/src/types/catalogs-products.d.ts
+++ b/src/types/catalogs-products.d.ts
@@ -132,6 +132,7 @@ export interface CatalogReleaseProductFilterAttributes {
   manufacturer_part_num?: string
   upc_ean?: string
 }
+
 export interface CatalogReleaseProductFilter {
   eq?: CatalogReleaseProductFilterAttributes
   in?: CatalogReleaseProductFilterAttributes
@@ -146,51 +147,40 @@ export interface CatalogsProductsEndpoint {
 
   Filter(filter: CatalogReleaseProductFilter): CatalogsProductsEndpoint
 
-  All(options: {
-    token?: string
-    additionalHeaders?: any
-  }): Promise<ResourceList<ProductResponse>>
-
-  Get(options: {
-    productId: string
-    token?: string
-    additionalHeaders?: any
-  }): Promise<Resource<ProductResponse>>
-
-  GetProduct(options: {
+  GetCatalogReleaseProduct(options: {
     catalogId: string
     releaseId: string
     productId: string
     token?: string
-    additionalHeaders?: any
-  }): Promise<Resource<ProductResponse>>
+  }): Promise<Resource<PcmProduct>>
 
-  GetCatalogNodeProducts(options: {
+  GetAllCatalogReleaseProducts(options: {
+    catalogId: string
+    releaseId: string
+    token?: string
+  }): Promise<ResourcePage<PcmProduct>>
+
+  GetCatalogReleaseProductChildren(options: {
+    catalogId: string
+    releaseId: string
+    productId: string
+    token?: string
+  }): Promise<ResourcePage<PcmProduct>>
+
+  GetCatalogReleaseNodeProducts(options: {
     catalogId: string
     releaseId: string
     nodeId: string
     token?: string
   }): Promise<ResourceList<NodeProductResponse>>
 
-  // TODO: Endpoint doesn't exist - replace / remove
-  GetProductsByNode(options: {
-    nodeId: string
-    token?: string
-    additionalHeaders?: any
-  }): Promise<ResourceList<ProductResponse>>
-
-  GetCatalogProducts(options: {
+  GetCatalogReleaseHierarchyProducts(options: {
     catalogId: string
     releaseId: string
+    hierarchyId: string
     token?: string
-  }): Promise<ResourcePage<PcmProduct>>
+  }): Promise<ResourceList<PcmProduct>>
 
-  GetCatalogProductChildren(options: {
-    catalogId: string
-    releaseId: string
-    productId: string
-    token?: string
-  }): Promise<ResourcePage<PcmProduct>>
   /**
    * @deprecated The method should not be used. Instead, use
    * @function GetCatalogProducts


### PR DESCRIPTION
## Type

* ### Feature

## Description

BREAKING CHANGE: Added moltin instance to GetCatalogProducts method so that the filter and other query params are not retained between calls on the same endpoint. Updated filter types for the same endpoint. Mark "GetProductsInCatalogRelease" as deprecated since it has the same functionality as the aforementioned method.

Pushed a commit where I removed methods that call these non-existent endpoints:
- `catalogs/products/${productId}`
- `catalogs/nodes/${nodeId}/relationships/products`
- `catalogs/products`
Also added:
- GetCatalogReleaseHierarchyProducts
- GetCatalogReleaseProductChildren

Renamed the methods within the Catalogs.Products class and fixed the relevant types.
