### PR TITLE
Feat: Add sort_order to variation and variation option interfaces

### DIFF
--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -18,6 +18,7 @@ import {
   export interface PCMVariationBase {
       attributes: {
         name: string
+        sort_order?: number
       }
   }
 
@@ -37,6 +38,7 @@ import {
     attributes: {
         name: string
         description: string
+        sort_order?: number
     }
   }
 


### PR DESCRIPTION
## Type

* ### Feature

## Description

- Add 'sort_order' field to variation and variation option interfaces.

Related issue: https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/280
