### PR TITLE
Feat!: Corrected variation and variation option response and update body types

### DIFF
--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -6,262 +6,288 @@
 import {
   Identifiable,
   CrudQueryableResource,
-  RelationshipToMany,
   Resource,
-  ResourceList, ResourcePage,
+  ResourceList,
+  ResourcePage
 } from './core'
 
+/**
+ * Product Variations Base Interface
+ */
+export interface PCMVariationBase {
+  attributes: {
+    name: string
+    sort_order?: number
+  }
+}
+
+export interface PCMVariation extends Identifiable, PCMVariationBase {
+  type: 'product-variation'
+  meta?: {
+    options?: PCMVariationMetaOption[]
+    owner: 'organization' | 'store'
+  }
+}
+
+/**
+ * Product variation option base interface
+ */
+
+export interface PCMVariationOptionBase {
+  type: 'product-variation-option'
+  attributes: {
+    name: string
+    description: string
+    sort_order?: number
+  }
+}
+
+export type PCMVariationMetaOption = Identifiable &
+  PCMVariationOptionBase['attributes']
+
+export interface VariationsOptionResponse
+  extends Identifiable,
+    PCMVariationOptionBase {
+  meta: {
+    owner?: 'organization' | 'store'
+    modifiers?: VariationsModifierTypeObj[]
+  }
+}
+
+export interface UpdateVariationBody extends PCMVariationBase, Identifiable {
+  attributes: PCMVariationBase['attributes'] & {
+    sort_order?: number | null
+  }
+}
+
+export interface UpdateVariationOptionBody
+  extends PCMVariationOptionBase,
+    Identifiable {
+  type: 'product-variation-option'
+  attributes: PCMVariationOptionBase['attributes'] & {
+    sort_order?: number | null
+  }
+}
+
+/**
+ * Modifiers object
+ * Modifiers help augmenting properties of a variation of a product, price, etc., by creating an array of child products or prices.
+ */
+export interface VariationsModifier {
+  attributes: {
+    type: VariationsModifierType
+    value?: string
+    seek?: string
+    set?: string
+    reference_name?: string
+  }
+}
+
+export interface VariationsModifierResponse
+  extends Identifiable,
+    VariationsModifier {
+  type: 'product-variation-modifier'
+}
+
+export type VariationsModifierTypeObj =
+  | { name_equals: string }
+  | { name_append: string }
+  | { name_prepend: string }
+  | { description_equals: string }
+  | { description_append: string }
+  | { description_prepend: string }
+  | { commoditytype: string }
+  | { slug_equals: string }
+  | { slug_append: string }
+  | { slug_prepend: string }
+  | { slug_builder: VariationsBuilderModifier }
+  | { sku_equals: string }
+  | { sku_append: string }
+  | { sku_prepend: string }
+  | { sku_builder: VariationsBuilderModifier }
+  | { status: string }
+
+export type VariationsModifierType =
+  | 'name_equals'
+  | 'name_append'
+  | 'name_prepend'
+  | 'description_equals'
+  | 'description_append'
+  | 'description_prepend'
+  | 'commodity_type'
+  | 'slug_equals'
+  | 'slug_append'
+  | 'slug_prepend'
+  | 'slug_builder'
+  | 'sku_equals'
+  | 'sku_append'
+  | 'sku_prepend'
+  | 'sku_builder'
+  | 'status'
+  | 'price'
+
+export interface VariationsBuilderModifier {
+  seek: string
+  set: string
+}
+
+/**
+ * Variations Endpoints
+ * Get DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/get-a-product-variation.html
+ * Get All DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/create-a-product-variation.html
+ * Delete DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/delete-a-product-variation.html
+ */
+export interface PCMVariationsEndpoint
+  extends CrudQueryableResource<
+    PCMVariation,
+    PCMVariationBase,
+    VariationsOptionResponse,
+    never,
+    never,
+    never
+  > {
+  endpoint: 'pcm/variations'
+
+  Limit(value: number): PCMVariationsEndpoint
+
+  Offset(value: number): PCMVariationsEndpoint
 
   /**
-   * Product Variations Base Interface
+   * Create a product variation
+   * @param body - The base variation object.
+   * @constructor
    */
-  export interface PCMVariationBase {
-      attributes: {
-        name: string
-        sort_order?: number | null
-      }
-  }
-
-  export interface PCMVariation extends Identifiable, PCMVariationBase {
-    type: 'product-variation'
-    meta?: {
-      options?: PCMVariationMetaOption[]
-      owner: 'organization' | 'store'
-    }
-  }
+  CreateVariation(body: PCMVariationBase): Promise<Resource<PCMVariation>>
 
   /**
-   * The Product Variation Option object
-   * A variation option represents an option for selection for a single product-variation.
+   * Update a product variation
+   * @param id - ID of the variation.
+   * @param body - The variation object.
+   * @param token - a token to access specific data.
+   * @constructor
    */
-  export interface VariationsOption {
-    attributes: {
-        name: string
-        description: string
-        sort_order?: number | null
-    }
-  }
-
-  export type PCMVariationMetaOption = Identifiable & VariationsOption['attributes']
-
-  export interface VariationsOptionResponse extends Identifiable {
-    type: 'product-variation-option'
-    attributes : {
-        name: string
-        description: string
-    }
-    relationships: {
-      modifiers: {
-        data: VariationsModifierTypeObj[]
-      }
-    }
-  }
-
-  export interface UpdateVariation extends PCMVariationBase, Identifiable {}
-
-  export interface UpdateVariationOption extends VariationsOption, Identifiable {}
+  UpdateVariation(
+    id: string,
+    body: UpdateVariationBody,
+    token?: string
+  ): Promise<Resource<PCMVariation>>
 
   /**
-   * Modifiers object
-   * Modifiers help augmenting properties of a variation of a product, price, etc., by creating an array of child products or prices.
+   * Get a product variation option
+   * Description: Use this endpoint to retrieve a single variation option.
+   * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/options/get-a-product-variation-option.html
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @constructor
    */
-  export interface VariationsModifier {
-      attributes: {
-        type: VariationsModifierType
-        value?: string
-        seek?: string
-        set?: string
-        reference_name?: string
-      }
-  }
-
-  export interface VariationsModifierResponse extends Identifiable, VariationsModifier {
-    type: 'product-variation-modifier'
-  }
-
-  export type VariationsModifierTypeObj =
-    | { name_equals: string }
-    | { name_append: string }
-    | { name_prepend: string }
-    | { description_equals: string }
-    | { description_append: string }
-    | { description_prepend: string }
-    | { commoditytype: string }
-    | { slug_equals: string }
-    | { slug_append: string }
-    | { slug_prepend: string }
-    | { slug_builder: VariationsBuilderModifier }
-    | { sku_equals: string }
-    | { sku_append: string }
-    | { sku_prepend: string }
-    | { sku_builder: VariationsBuilderModifier }
-    | { status: string }
-
-  export type VariationsModifierType =
-    | 'name_equals'
-    | 'name_append'
-    | 'name_prepend'
-    | 'description_equals'
-    | 'description_append'
-    | 'description_prepend'
-    | 'commodity_type'
-    | 'slug_equals'
-    | 'slug_append'
-    | 'slug_prepend'
-    | 'slug_builder'
-    | 'sku_equals'
-    | 'sku_append'
-    | 'sku_prepend'
-    | 'sku_builder'
-    | 'status'
-    | 'price'
-
-  export interface VariationsBuilderModifier {
-    seek: string
-    set: string
-  }
+  VariationsOption(
+    variationId: string,
+    optionId: string
+  ): Promise<Resource<VariationsOptionResponse>>
 
   /**
-   * Variations Endpoints
-   * Get DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/get-a-product-variation.html
-   * Get All DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/create-a-product-variation.html
-   * Delete DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/delete-a-product-variation.html
+   * Get all product variation options
+   * @param variationId - ID of the variation.
+   * @constructor
    */
-  export interface PCMVariationsEndpoint
-    extends CrudQueryableResource<
-        PCMVariation,
-        PCMVariationBase,
-        VariationsOptionResponse,
-        never,
-        never,
-        never
-      > {
-    endpoint: 'pcm/variations'
+  VariationsOptions(
+    variationId: string
+  ): Promise<ResourcePage<VariationsOptionResponse>>
 
-    Limit(value: number): PCMVariationsEndpoint
+  /**
+   * Create a product variation option
+   * @param variationId - ID of the variation.
+   * @param body - The option object.
+   * @constructor
+   */
+  CreateVariationsOption(
+    variationId: string,
+    body: PCMVariationOptionBase
+  ): Promise<Resource<VariationsOptionResponse>>
 
-    Offset(value: number): PCMVariationsEndpoint
+  /**
+   * Update product variation option
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @param body - The option object.
+   * @constructor
+   */
+  UpdateVariationsOption(
+    variationId: string,
+    optionId: string,
+    body: UpdateVariationOptionBody
+  ): Promise<Resource<VariationsOptionResponse>>
 
-    /**
-     * Create a product variation
-     * @param body - The variation object.
-     * @constructor
-     */
-    CreateVariation(body: PCMVariationBase): Promise<Resource<PCMVariation>>
+  /**
+   * Delete product variation option
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @constructor
+   */
+  DeleteVariationsOption(variationId: string, optionId: string): Promise<{}>
 
-    /**
-     * Update a product variation
-     * @param id - ID of the variation.
-     * @param body - The variation object.
-     * @param token - a token to access specific data.
-     * @constructor
-     */
-    UpdateVariation(
-      id: string,
-      body: UpdateVariation,
-      token?: string
-    ): Promise<Resource<PCMVariation>>
+  /**
+   * Get a product modifier
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @param modifierId - ID of the modifier.
+   * @constructor
+   */
+  VariationsModifier(
+    variationId: string,
+    optionId: string,
+    modifierId: string
+  ): Promise<Resource<VariationsModifierResponse>>
 
-    /**
-     * Get a product variation option
-     * Description: Use this endpoint to retrieve a single variation option.
-     * DOCS: https://documentation.elasticpath.com/commerce-cloud/docs/api/catalog/product-variations/options/get-a-product-variation-option.html
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @constructor
-     */
-    VariationsOption(
-      variationId: string,
-      optionId: string
-    ): Promise<Resource<VariationsOptionResponse>>
+  /**
+   * Get all product modifiers
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @constructor
+   */
+  VariationsModifiers(
+    variationId: string,
+    optionId: string
+  ): Promise<ResourceList<VariationsModifierResponse>>
 
-    /**
-     * Get all product variation options
-     * @param variationId - ID of the variation.
-     * @constructor
-     */
-    VariationsOptions(variationId: string): Promise<ResourcePage<VariationsOptionResponse>>
+  /**
+   * Create a new product modifier
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @param body - The modifier object.
+   * @constructor
+   */
+  CreateVariationsModifier(
+    variationId: string,
+    optionId: string,
+    body: VariationsModifier
+  ): Promise<Resource<VariationsModifierResponse>>
 
-    /**
-     * Create a product variation option
-     * @param variationId - ID of the variation.
-     * @param body - The option object.
-     * @constructor
-     */
-    CreateVariationsOption(variationId: string, body: VariationsOption): Promise<Resource<VariationsOptionResponse>>
+  /**
+   * Update a product modifier
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @param modifierId - ID of the modifier.
+   * @param body - The modifier object.
+   * @constructor
+   */
+  UpdateVariationsModifier(
+    variationId: string,
+    optionId: string,
+    modifierId: string,
+    body: VariationsModifier
+  ): Promise<Resource<VariationsModifierResponse>>
 
-    /**
-     * Update product variation option
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @param body - The option object.
-     * @constructor
-     */
-    UpdateVariationsOption(variationId: string, optionId: string, body: UpdateVariationOption): Promise<Resource<VariationsOptionResponse>>
-
-    /**
-     * Delete product variation option
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @constructor
-     */
-    DeleteVariationsOption(variationId: string, optionId: string): Promise<{}>
-
-    /**
-     * Get a product modifier
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @param modifierId - ID of the modifier.
-     * @constructor
-     */
-    VariationsModifier(
-      variationId: string,
-      optionId: string,
-      modifierId: string
-    ): Promise<Resource<VariationsModifierResponse>>
-
-    /**
-     * Get all product modifiers
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @constructor
-     */
-    VariationsModifiers(variationId: string, optionId: string): Promise<ResourceList<VariationsModifierResponse>>
-
-    /**
-     * Create a new product modifier
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @param body - The modifier object.
-     * @constructor
-     */
-    CreateVariationsModifier(
-      variationId: string,
-      optionId: string,
-      body: VariationsModifier
-    ): Promise<Resource<VariationsModifierResponse>>
-
-    /**
-     * Update a product modifier
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @param modifierId - ID of the modifier.
-     * @param body - The modifier object.
-     * @constructor
-     */
-    UpdateVariationsModifier(
-      variationId: string,
-      optionId: string,
-      modifierId: string,
-      body: VariationsModifier
-    ): Promise<Resource<VariationsModifierResponse>>
-
-    /**
-     * Delete a product modifier
-     * @param variationId - ID of the variation.
-     * @param optionId - ID of the option.
-     * @param modifierId - ID of the modifier.
-     * @constructor
-     */
-    DeleteVariationsModifier(variationId: string, optionId: string, modifierId: string): Promise<{}>
-  }
+  /**
+   * Delete a product modifier
+   * @param variationId - ID of the variation.
+   * @param optionId - ID of the option.
+   * @param modifierId - ID of the modifier.
+   * @constructor
+   */
+  DeleteVariationsModifier(
+    variationId: string,
+    optionId: string,
+    modifierId: string
+  ): Promise<{}>
+}

--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -38,7 +38,6 @@ export interface UpdateVariationBody extends PCMVariationBase, Identifiable {
 /**
  * Product variation option base interface
  */
-
 export interface PCMVariationOptionBase {
   type: 'product-variation-option'
   attributes: {
@@ -66,6 +65,9 @@ export interface UpdateVariationOptionBody
   }
 }
 
+/**
+ * Interface for options that are in a PCM Variation's meta.options field
+ */
 export type PCMVariationMetaOption = Identifiable &
   PCMVariationOptionBase['attributes']
 

--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -29,6 +29,12 @@ export interface PCMVariation extends Identifiable, PCMVariationBase {
   }
 }
 
+export interface UpdateVariationBody extends PCMVariationBase, Identifiable {
+  attributes: PCMVariationBase['attributes'] & {
+    sort_order?: number | null
+  }
+}
+
 /**
  * Product variation option base interface
  */
@@ -42,21 +48,12 @@ export interface PCMVariationOptionBase {
   }
 }
 
-export type PCMVariationMetaOption = Identifiable &
-  PCMVariationOptionBase['attributes']
-
-export interface VariationsOptionResponse
+export interface PCMVariationOption
   extends Identifiable,
     PCMVariationOptionBase {
   meta: {
     owner?: 'organization' | 'store'
     modifiers?: VariationsModifierTypeObj[]
-  }
-}
-
-export interface UpdateVariationBody extends PCMVariationBase, Identifiable {
-  attributes: PCMVariationBase['attributes'] & {
-    sort_order?: number | null
   }
 }
 
@@ -68,6 +65,9 @@ export interface UpdateVariationOptionBody
     sort_order?: number | null
   }
 }
+
+export type PCMVariationMetaOption = Identifiable &
+  PCMVariationOptionBase['attributes']
 
 /**
  * Modifiers object
@@ -141,7 +141,7 @@ export interface PCMVariationsEndpoint
   extends CrudQueryableResource<
     PCMVariation,
     PCMVariationBase,
-    VariationsOptionResponse,
+    PCMVariationOption,
     never,
     never,
     never
@@ -183,7 +183,7 @@ export interface PCMVariationsEndpoint
   VariationsOption(
     variationId: string,
     optionId: string
-  ): Promise<Resource<VariationsOptionResponse>>
+  ): Promise<Resource<PCMVariationOption>>
 
   /**
    * Get all product variation options
@@ -192,7 +192,7 @@ export interface PCMVariationsEndpoint
    */
   VariationsOptions(
     variationId: string
-  ): Promise<ResourcePage<VariationsOptionResponse>>
+  ): Promise<ResourcePage<PCMVariationOption>>
 
   /**
    * Create a product variation option
@@ -203,7 +203,7 @@ export interface PCMVariationsEndpoint
   CreateVariationsOption(
     variationId: string,
     body: PCMVariationOptionBase
-  ): Promise<Resource<VariationsOptionResponse>>
+  ): Promise<Resource<PCMVariationOption>>
 
   /**
    * Update product variation option
@@ -216,7 +216,7 @@ export interface PCMVariationsEndpoint
     variationId: string,
     optionId: string,
     body: UpdateVariationOptionBody
-  ): Promise<Resource<VariationsOptionResponse>>
+  ): Promise<Resource<PCMVariationOption>>
 
   /**
    * Delete product variation option


### PR DESCRIPTION

## Type

* ### Feature

## Description

BREAKING CHANGES:

- Fix base types for variation and variation options
- Update body is different from respective base when it comes to the `sort_order` field. It can include the null value
- Variation option response type was corrected

