### PR TITLE
Fix: Variation option base type and update body corrections

### DIFF
--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -11,15 +11,6 @@ import {
   ResourcePage
 } from './core'
 
-
-// UpdateBody helper types
-type MapToNull<PropType> = PropType extends number | undefined
-  ? number | undefined | null
-  : PropType
-type MappedType<T> = {
-  [PropertyKey in keyof T]: MapToNull<T[PropertyKey]>
-}
-
 /**
  * Product Variations Base Interface
  */
@@ -37,8 +28,18 @@ export interface PCMVariation extends Identifiable, PCMVariationBase {
     owner: 'organization' | 'store'
   }
 }
-export interface UpdateVariationBody extends Omit<PCMVariationBase, 'attributes'>, Identifiable {
-  attributes: MappedType<PCMVariationBase['attributes']>
+
+type PartialVariationBodyAttributes = Omit<
+  PCMVariationBase['attributes'],
+  'sort_order'
+>
+
+export interface UpdateVariationBody
+  extends Omit<PCMVariationBase, 'attributes'>,
+    Identifiable {
+  attributes: PartialVariationBodyAttributes & {
+    sort_order?: number | null
+  }
 }
 
 /**
@@ -62,10 +63,17 @@ export interface PCMVariationOption
   }
 }
 
+type PartialVariationOptionBodyAttributes = Omit<
+  PCMVariationOptionBase['attributes'],
+  'sort_order'
+>
+
 export interface UpdateVariationOptionBody
   extends Omit<PCMVariationOptionBase, 'attributes'>,
     Identifiable {
-  attributes: MappedType<PCMVariationOptionBase['attributes']>
+  attributes: PartialVariationOptionBodyAttributes & {
+    sort_order?: number | null
+  }
 }
 
 /**

--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -11,6 +11,15 @@ import {
   ResourcePage
 } from './core'
 
+
+// UpdateBody helper types
+type MapToNull<PropType> = PropType extends number | undefined
+  ? number | undefined | null
+  : PropType
+type MappedType<T> = {
+  [PropertyKey in keyof T]: MapToNull<T[PropertyKey]>
+}
+
 /**
  * Product Variations Base Interface
  */
@@ -28,18 +37,14 @@ export interface PCMVariation extends Identifiable, PCMVariationBase {
     owner: 'organization' | 'store'
   }
 }
-
-export interface UpdateVariationBody extends PCMVariationBase, Identifiable {
-  attributes: PCMVariationBase['attributes'] & {
-    sort_order?: number | null
-  }
+export interface UpdateVariationBody extends Omit<PCMVariationBase, 'attributes'>, Identifiable {
+  attributes: MappedType<PCMVariationBase['attributes']>
 }
 
 /**
  * Product variation option base interface
  */
 export interface PCMVariationOptionBase {
-  type: 'product-variation-option'
   attributes: {
     name: string
     description: string
@@ -50,6 +55,7 @@ export interface PCMVariationOptionBase {
 export interface PCMVariationOption
   extends Identifiable,
     PCMVariationOptionBase {
+  type: 'product-variation-option'
   meta: {
     owner?: 'organization' | 'store'
     modifiers?: VariationsModifierTypeObj[]
@@ -57,12 +63,9 @@ export interface PCMVariationOption
 }
 
 export interface UpdateVariationOptionBody
-  extends PCMVariationOptionBase,
+  extends Omit<PCMVariationOptionBase, 'attributes'>,
     Identifiable {
-  type: 'product-variation-option'
-  attributes: PCMVariationOptionBase['attributes'] & {
-    sort_order?: number | null
-  }
+  attributes: MappedType<PCMVariationOptionBase['attributes']>
 }
 
 /**

--- a/src/types/pcm-variations.ts
+++ b/src/types/pcm-variations.ts
@@ -29,15 +29,11 @@ export interface PCMVariation extends Identifiable, PCMVariationBase {
   }
 }
 
-type PartialVariationBodyAttributes = Omit<
-  PCMVariationBase['attributes'],
-  'sort_order'
->
-
 export interface UpdateVariationBody
   extends Omit<PCMVariationBase, 'attributes'>,
     Identifiable {
-  attributes: PartialVariationBodyAttributes & {
+  attributes: {
+    name: string
     sort_order?: number | null
   }
 }
@@ -63,15 +59,12 @@ export interface PCMVariationOption
   }
 }
 
-type PartialVariationOptionBodyAttributes = Omit<
-  PCMVariationOptionBase['attributes'],
-  'sort_order'
->
-
 export interface UpdateVariationOptionBody
   extends Omit<PCMVariationOptionBase, 'attributes'>,
     Identifiable {
-  attributes: PartialVariationOptionBodyAttributes & {
+  attributes:  {
+    name: string
+    description: string
     sort_order?: number | null
   }
 }


### PR DESCRIPTION
…e body type for variation and variation option

## Type

* ### Fix

## Description

- PCMVariationOptionBase - removed 'type' field and added it to PCMVariationOption type
- Fixed UpdateBody types for Variation and Variation Option to properly add the null | number | undefined type to the sort_order field
