### PR TITLE
feat: Added useTemplateSlugs query param as optional argument to PCM.ExportProducts method

### DIFF
--- a/src/endpoints/pcm.js
+++ b/src/endpoints/pcm.js
@@ -62,10 +62,11 @@ class PCMEndpoint extends CRUDExtend {
     return this.request.send(`${this.endpoint}/detach_nodes`, 'POST', body)
   }
 
-  ExportProducts(filter) {
+  ExportProducts(filter, useTemplateSlugs) {
     return this.request.send(
         buildURL(`${this.endpoint}/export`, {
-          filter
+          filter,
+          useTemplateSlugs
         }),
         'POST'
     )

--- a/src/types/pcm.d.ts
+++ b/src/types/pcm.d.ts
@@ -243,5 +243,5 @@ export interface PcmProductsEndpoint
    * @param filter - products filters
    * @constructor
    */
-  ExportProducts(filter?: PcmProductFilter): Promise<Resource<PcmJob>>
+  ExportProducts(filter?: PcmProductFilter, useTemplateSlugs?: boolean): Promise<Resource<PcmJob>>
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -120,7 +120,7 @@ function formatQueryString(key, value) {
   return `${key}=${value}`
 }
 
-function buildQueryParams({ includes, sort, limit, offset, filter }) {
+function buildQueryParams({ includes, sort, limit, offset, filter, useTemplateSlugs}) {
   const query = {}
 
   if (includes) {
@@ -143,6 +143,10 @@ function buildQueryParams({ includes, sort, limit, offset, filter }) {
     query.filter = filter
   }
 
+  if(useTemplateSlugs) {
+    query.useTemplateSlugs = useTemplateSlugs
+  }
+
   return Object.keys(query)
     .map(k => formatQueryString(k, query[k]))
     .join('&')
@@ -160,13 +164,13 @@ export function buildURL(endpoint, params) {
     params.sort ||
     params.limit ||
     params.offset ||
-    params.filter
+    params.filter ||
+    params.useTemplateSlugs
   ) {
     const paramsString = buildQueryParams(params)
 
     return `${endpoint}?${paramsString}`
   }
-
   return endpoint
 }
 


### PR DESCRIPTION
## Type

* ### Feature

## Description

- Updated `PCM.ExportProducts` method with a second optional boolean argument for the value of the `useTemplateSlugs` query param
- `buildURL` and `buildQueryParams` helper functions have been updated to accept  and append the `useTemplateSlugs` param to the final URL

Relevant Issue: https://gitlab.elasticpath.com/commerce-cloud/ncl-projects/paragon/team/-/issues/283