### PR TITLE
refactor(custom apis): updated entries to use id instead of slug

### DIFF
--- a/src/endpoints/custom-apis.js
+++ b/src/endpoints/custom-apis.js
@@ -7,7 +7,6 @@ class CustomApisEndpoint extends CRUDExtend {
     super(endpoint)
 
     this.endpoint = 'settings/extensions/custom-apis'
-    this.entriesEndpoint = 'extensions'
   }
 
   Create(body) {
@@ -69,11 +68,11 @@ class CustomApisEndpoint extends CRUDExtend {
     )
   }
 
-  GetEntries(customApiSlug) {
+  GetEntries(customApiId) {
     const { limit, offset, sort, filter } = this
 
     return this.request.send(
-      buildURL(`${this.entriesEndpoint}/${customApiSlug}`, {
+      buildURL(`${this.endpoint}/${customApiId}/entries`, {
         limit,
         offset,
         sort,
@@ -83,32 +82,32 @@ class CustomApisEndpoint extends CRUDExtend {
     )
   }
 
-  GetEntry(customApiSlug, customApiEntryId) {
+  GetEntry(customApiId, customApiEntryId) {
     return this.request.send(
-      `${this.entriesEndpoint}/${customApiSlug}/${customApiEntryId}`,
+      `${this.endpoint}/${customApiId}/entries/${customApiEntryId}`,
       'GET'
     )
   }
 
-  CreateEntry(customApiSlug, body) {
+  CreateEntry(customApiId, body) {
     return this.request.send(
-      `${this.entriesEndpoint}/${customApiSlug}`,
+      `${this.endpoint}/${customApiId}/entries`,
       'POST',
       body
     )
   }
 
-  UpdateEntry(customApiSlug, customApiEntryId, body) {
+  UpdateEntry(customApiId, customApiEntryId, body) {
     return this.request.send(
-      `${this.entriesEndpoint}/${customApiSlug}/${customApiEntryId}`,
+      `${this.endpoint}/${customApiId}/entries/${customApiEntryId}`,
       'PUT',
       body
     )
   }
 
-  DeleteEntry(customApiSlug, customApiEntryId) {
+  DeleteEntry(customApiId, customApiEntryId) {
     return this.request.send(
-      `${this.entriesEndpoint}/${customApiSlug}/${customApiEntryId}`,
+      `${this.endpoint}/${customApiId}/entries/${customApiEntryId}`,
       'DELETE'
     )
   }

--- a/src/types/custom-apis.ts
+++ b/src/types/custom-apis.ts
@@ -97,21 +97,21 @@ export interface CustomApisEndpoint {
 
   DeleteField<T = any>(customApiId: string, customApiFieldId: string): Promise<T>
   
-  GetEntries<T = any>(customApiSlug: string): Promise<T>
+  GetEntries<T = any>(customApiId: string): Promise<T>
 
-  GetEntry<T = any>(customApiSlug: string, customApiEntryId: string): Promise<T>
+  GetEntry<T = any>(customApiId: string, customApiEntryId: string): Promise<T>
 
   CreateEntry<RequestBody = any, ResponseBody = any>(
-    customApiSlug: string,
+    customApiId: string,
     body: RequestBody
   ): Promise<ResponseBody>
 
   UpdateEntry<RequestBody = any, ResponseBody = any>(
-    customApiSlug: string,
+    customApiId: string,
     customApiEntryId: string,
     body: RequestBody
   ): Promise<ResponseBody>
 
-  DeleteEntry<T = any>(customApiSlug: string, customApiEntryId: string): Promise<T>
+  DeleteEntry<T = any>(customApiId: string, customApiEntryId: string): Promise<T>
 
 }


### PR DESCRIPTION
BREAKING CHANGE: changed the endpoint in entries and it now uses customApiId instead of customApiSlug

## Type

* ### Refactor
  A code change that neither fixes a bug nor adds a feature

## Description

*Changed the endpoint in entries and it now uses `customApiId` instead of `customApiSlug`*

